### PR TITLE
fix: data race in Addr() and iouring tier write

### DIFF
--- a/adaptive/engine.go
+++ b/adaptive/engine.go
@@ -33,7 +33,7 @@ type Engine struct {
 	ctrl      *controller
 	cfg       resource.Config
 	handler   stream.Handler
-	addr      net.Addr
+	addr      atomic.Pointer[net.Addr]
 	mu        sync.Mutex
 	frozen    atomic.Bool
 	logger    *slog.Logger
@@ -153,9 +153,8 @@ func (e *Engine) Listen(ctx context.Context) error {
 		return fmt.Errorf("sub-engines failed to initialize")
 	}
 
-	e.mu.Lock()
-	e.addr = e.primary.Addr()
-	e.mu.Unlock()
+	addr := e.primary.Addr()
+	e.addr.Store(&addr)
 
 	// Pause standby engine's accept.
 	if e.ctrl.state.activeIsPrimary {
@@ -272,9 +271,10 @@ func (e *Engine) Type() engine.EngineType {
 
 // Addr returns the bound listener address.
 func (e *Engine) Addr() net.Addr {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	return e.addr
+	if p := e.addr.Load(); p != nil {
+		return *p
+	}
+	return nil
 }
 
 // FreezeSwitching prevents the controller from switching engines.

--- a/engine/epoll/engine.go
+++ b/engine/epoll/engine.go
@@ -21,7 +21,7 @@ type Engine struct {
 	loops        []*Loop
 	cfg          resource.Config
 	handler      stream.Handler
-	addr         net.Addr
+	addr         atomic.Pointer[net.Addr]
 	mu           sync.Mutex
 	acceptPaused atomic.Bool
 	metrics      struct {
@@ -64,10 +64,11 @@ func (e *Engine) Listen(ctx context.Context) error {
 		}
 		e.loops[i] = l
 	}
-	if len(e.loops) > 0 {
-		e.addr = boundAddr(e.loops[0].listenFD)
-	}
 	e.mu.Unlock()
+	if len(e.loops) > 0 {
+		addr := boundAddr(e.loops[0].listenFD)
+		e.addr.Store(&addr)
+	}
 
 	var wg sync.WaitGroup
 	for _, l := range e.loops {
@@ -116,7 +117,8 @@ func (e *Engine) ResumeAccept() error {
 
 // Addr returns the bound listener address.
 func (e *Engine) Addr() net.Addr {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	return e.addr
+	if p := e.addr.Load(); p != nil {
+		return *p
+	}
+	return nil
 }

--- a/engine/iouring/engine.go
+++ b/engine/iouring/engine.go
@@ -25,7 +25,7 @@ type Engine struct {
 	profile      engine.CapabilityProfile
 	cfg          resource.Config
 	handler      stream.Handler
-	addr         net.Addr
+	addr         atomic.Pointer[net.Addr]
 	mu           sync.Mutex
 	acceptPaused atomic.Bool
 	metrics      struct {
@@ -92,8 +92,6 @@ func (e *Engine) Listen(ctx context.Context) error {
 		)
 		tier = lower
 	}
-	e.tier = tier
-
 	workers, err := e.createWorkers(tier, cpus, objective, resolved)
 	if err != nil {
 		return fmt.Errorf("worker init: %w", err)
@@ -124,11 +122,13 @@ func (e *Engine) Listen(ctx context.Context) error {
 	}
 
 	e.mu.Lock()
+	e.tier = tier
 	e.workers = workers
-	if len(workers) > 0 {
-		e.addr = boundAddr(workers[0].listenFD)
-	}
 	e.mu.Unlock()
+	if len(workers) > 0 {
+		addr := boundAddr(workers[0].listenFD)
+		e.addr.Store(&addr)
+	}
 
 	e.cfg.Logger.Info("io_uring engine listening", "addr", e.cfg.Addr, "tier", tier.Tier().String(), "workers", resolved.Workers)
 
@@ -209,7 +209,8 @@ func (e *Engine) ResumeAccept() error {
 
 // Addr returns the bound listener address.
 func (e *Engine) Addr() net.Addr {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	return e.addr
+	if p := e.addr.Load(); p != nil {
+		return *p
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary
- Convert `addr` field from `net.Addr` to `atomic.Pointer[net.Addr]` in epoll, iouring, and adaptive engines for lock-free concurrent access
- Move `e.tier = tier` inside the existing mutex block in iouring `Listen()` to prevent unprotected write
- Fixes CI data race detected between `Listen()` and `Addr()` in both epoll and iouring engines

## Test plan
- [x] `GOOS=linux go build ./...` and `go vet ./...` pass
- [x] `golangci-lint run` passes
- [x] Local tests pass with `-race`
- [ ] CI conformance tests pass without data race warnings