### PR TITLE
fix: reuse CI workflow in release instead of duplicate test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,23 +21,14 @@ jobs:
           fi
           echo "Tag $TAG is valid"
 
-  test:
-    name: Test
+  ci:
+    name: CI
     needs: validate-tag
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
-        with:
-          go-version: "1.26"
-      - name: Build
-        run: go build ./...
-      - name: Test with race detector
-        run: go test -race -count=1 -timeout=120s ./...
+    uses: ./.github/workflows/ci.yml
 
   notify-proxy:
     name: Notify Go Proxy
-    needs: [validate-tag, test]
+    needs: [validate-tag, ci]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- The release workflow ran `go test ./...` independently from CI, so test failures could appear only at release time
- Replace the duplicate test job with `uses: ./.github/workflows/ci.yml` so both pipelines run the exact same lint, test, conformance, spec, and build jobs
- Add `workflow_call` trigger to `ci.yml` to support reuse

## Test plan
- [ ] CI runs on this PR (verifies `workflow_call` trigger doesn't break existing CI)
- [ ] Next release uses the reused CI workflow instead of its own test job