### PR TITLE
fix: serialize io_uring sends to prevent hangs under load

### DIFF
--- a/engine/iouring/conn.go
+++ b/engine/iouring/conn.go
@@ -19,7 +19,8 @@ type connState struct {
 	ctx       context.Context
 	cancel    context.CancelFunc
 	detected  bool
-	sendQueue [][]byte // FIFO queue of in-flight SEND buffers for partial send retry
+	sendQueue [][]byte // FIFO queue of pending SEND buffers
+	sending   bool     // true when a SEND SQE is in-flight for this connection
 	closing   bool     // defers close until all in-flight sends complete
 }
 

--- a/engine/iouring/worker.go
+++ b/engine/iouring/worker.go
@@ -141,6 +141,13 @@ func (w *Worker) run(ctx context.Context) {
 			processed++
 		}
 
+		// Retry pending sends that failed due to SQ ring being full.
+		for fd, cs := range w.conns {
+			if !cs.sending && len(cs.sendQueue) > 0 {
+				w.flushSend(fd)
+			}
+		}
+
 		if _, err := w.ring.Submit(); err != nil {
 			w.logger.Error("submit failed", "worker", w.id, "err", err)
 		}
@@ -298,14 +305,16 @@ func (w *Worker) handleRecv(c *completionEntry, fd int) {
 	w.reqCount.Add(1)
 
 	if processErr != nil {
-		// Submit pending SEND SQEs (e.g. error responses) before closing
-		// so the kernel processes the send before the close.
+		// Flush pending writes (e.g. error responses) before closing.
+		w.flushSend(fd)
 		if _, err := w.ring.Submit(); err != nil {
 			w.logger.Error("submit failed", "worker", w.id, "err", err)
 		}
 		w.closeConn(fd)
 		return
 	}
+
+	w.flushSend(fd)
 
 	if !cqeHasMore(c.Flags) {
 		w.tier.PrepareRecv(w.ring, fd, cs.buf)
@@ -318,6 +327,8 @@ func (w *Worker) handleSend(c *completionEntry, fd int) {
 		return
 	}
 
+	cs.sending = false
+
 	if c.Res < 0 {
 		w.errCount.Add(1)
 		cs.sendQueue = cs.sendQueue[:0]
@@ -329,24 +340,25 @@ func (w *Worker) handleSend(c *completionEntry, fd int) {
 		return
 	}
 
-	// Handle partial sends by re-sending the remainder.
+	// Handle partial sends by updating the front buffer with the remainder.
 	sent := int(c.Res)
 	if len(cs.sendQueue) > 0 {
 		buf := cs.sendQueue[0]
 		if sent < len(buf) {
-			remaining := buf[sent:]
-			newBuf := make([]byte, len(remaining))
-			copy(newBuf, remaining)
-			cs.sendQueue[0] = newBuf
-			w.tier.PrepareSend(w.ring, fd, newBuf, false)
-			return
+			cs.sendQueue[0] = buf[sent:]
+		} else {
+			cs.sendQueue = cs.sendQueue[1:]
 		}
-		cs.sendQueue = cs.sendQueue[1:]
 	}
 
 	if cs.closing && len(cs.sendQueue) == 0 {
 		w.finishClose(fd)
+		return
 	}
+
+	// Submit the next send (handles both partial-send retries and new data
+	// that arrived while this send was in flight).
+	w.flushSend(fd)
 }
 
 func (w *Worker) handleClose(fd int) {
@@ -364,10 +376,11 @@ func (w *Worker) closeConn(fd int) {
 	}
 	cs.cancel()
 
-	// Defer actual close until all in-flight SEND SQEs complete,
+	// Defer actual close until all in-flight and pending SENDs complete,
 	// so GOAWAY / RST_STREAM data reaches the client.
-	if len(cs.sendQueue) > 0 {
+	if cs.sending || len(cs.sendQueue) > 0 {
 		cs.closing = true
+		w.flushSend(fd)
 		return
 	}
 
@@ -402,8 +415,46 @@ func (w *Worker) makeWriteFn(fd int) func([]byte) {
 		if cs, ok := w.conns[fd]; ok {
 			cs.sendQueue = append(cs.sendQueue, copied)
 		}
-		w.tier.PrepareSend(w.ring, fd, copied, false)
+		// Don't submit a SEND SQE here. Sends are serialized per-connection
+		// via flushSend, called after recv processing and send completion.
 	}
+}
+
+// flushSend submits one coalesced SEND SQE for pending data on this connection.
+// Only one SEND is in-flight per connection at a time; if a send is already
+// in progress, this is a no-op and the next send will be triggered when the
+// current one completes.
+func (w *Worker) flushSend(fd int) {
+	cs, ok := w.conns[fd]
+	if !ok || cs.sending || len(cs.sendQueue) == 0 {
+		return
+	}
+
+	// Coalesce all pending buffers into one to minimize SQEs.
+	var buf []byte
+	if len(cs.sendQueue) == 1 {
+		buf = cs.sendQueue[0]
+	} else {
+		total := 0
+		for _, b := range cs.sendQueue {
+			total += len(b)
+		}
+		buf = make([]byte, 0, total)
+		for _, b := range cs.sendQueue {
+			buf = append(buf, b...)
+		}
+		cs.sendQueue = cs.sendQueue[:1]
+		cs.sendQueue[0] = buf
+	}
+
+	sqe := w.ring.GetSQE()
+	if sqe == nil {
+		// SQ ring full — will retry on next loop iteration.
+		return
+	}
+	prepSend(sqe, fd, buf, false)
+	setSQEUserData(sqe, encodeUserData(udSend, fd))
+	cs.sending = true
 }
 
 func (w *Worker) shutdown() {


### PR DESCRIPTION
## Summary

- **Root cause**: `makeWriteFn` submitted a SEND SQE immediately for every `write()` call, allowing multiple concurrent SENDs per FD. Under high concurrency with responses >13 bytes, this caused send queue / CQE mismatch on partial sends and silent SQE drops when the SQ ring filled up — both leading to connection hangs.
- **Fix**: Serialize sends per-connection. Only one SEND is in-flight per FD at a time. A new `flushSend` method coalesces all pending buffers into one SEND SQE. The main event loop retries connections with unsent data for SQ-full recovery.
- **Impact**: Fixes io_uring engine hanging under sustained benchmark load (both H1 and H2C protocols). Epoll and std engines are unaffected.

Fixes #34, fixes #35.

## Changes

- `conn.go`: Added `sending bool` field to track in-flight SEND per connection
- `worker.go`:
  - `makeWriteFn` — only appends to sendQueue, no longer calls `PrepareSend`
  - New `flushSend` — coalesces pending buffers, submits one SEND SQE, handles SQ-full gracefully
  - `handleRecv` — calls `flushSend` after processing
  - `handleSend` — clears `sending` flag, calls `flushSend` for next batch
  - `closeConn` — checks both `sending` and `sendQueue` before deferring close
  - Main loop — retries connections with unsent data (SQ-full recovery)

## Test plan

- [x] `GOOS=linux go build ./...` — compiles clean
- [x] `go test -race ./...` — all existing tests pass (macOS, io_uring skipped)
- [ ] CI conformance + spec tests (Linux) — validates H1 and H2 under io_uring
- [ ] Re-run benchmarks with `celeris-iouring-*` servers to verify no hangs