### PR TITLE
fix: suppress response body for HEAD requests (RFC 9110)

### DIFF
--- a/internal/conn/h1.go
+++ b/internal/conn/h1.go
@@ -138,7 +138,7 @@ func handleH1Request(ctx context.Context, req *h1.Request, body []byte, handler 
 
 	s := requestToStream(req, body)
 	defer s.Release()
-	rw := &h1ResponseAdapter{write: write, keepAlive: req.KeepAlive}
+	rw := &h1ResponseAdapter{write: write, keepAlive: req.KeepAlive, isHEAD: req.Method == "HEAD"}
 	s.ResponseWriter = rw
 
 	if err := handler.HandleStream(ctx, s); err != nil {

--- a/internal/conn/response.go
+++ b/internal/conn/response.go
@@ -50,6 +50,7 @@ func putResponseBuffer(p *[]byte) {
 type h1ResponseAdapter struct {
 	write     func([]byte)
 	keepAlive bool
+	isHEAD    bool
 }
 
 func (a *h1ResponseAdapter) WriteResponse(_ *stream.Stream, status int, headers [][2]string, body []byte) error {
@@ -88,7 +89,10 @@ func (a *h1ResponseAdapter) WriteResponse(_ *stream.Stream, status int, headers 
 
 	buf = append(buf, crlf...)
 
-	if len(body) > 0 {
+	// RFC 9110 §9.3.2: HEAD responses MUST NOT contain a message body.
+	// Content-Length is still included above to indicate the size that
+	// would be returned for a GET, but no bytes are sent.
+	if len(body) > 0 && !a.isHEAD {
 		buf = append(buf, body...)
 	}
 


### PR DESCRIPTION
## Summary

- **Bug**: H1 response writer sent body bytes for HEAD requests, violating RFC 9110 §9.3.2. On keep-alive connections, the unread body data corrupted subsequent responses — the client parsed leftover bytes (e.g., `HEAD /test`) concatenated with the next response's status line as a malformed status code (`/testHTTP/1.1`).
- **Fix**: Added `isHEAD` flag to `h1ResponseAdapter`. When set, `WriteResponse` includes `Content-Length` (indicating what a GET would return) but omits the body bytes.

This was the root cause of the `TestConformanceMatrix/epoll/auto/BasicMethods/OPTIONS` failure in the v0.3.5 release.

## Test plan

- [ ] Conformance tests pass: `go test -race ./test/conformance/...`
- [ ] Verify `epoll/auto/BasicMethods/OPTIONS` no longer fails
- [ ] Verify no "Unsolicited response received on idle HTTP channel" warnings