### PR TITLE
fix: allow pre-release tags in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ jobs:
       - name: Check semver format
         run: |
           TAG="${{ github.event.release.tag_name }}"
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Tag '$TAG' is not valid semver (expected vX.Y.Z)"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$ ]]; then
+            echo "::error::Tag '$TAG' is not valid semver (expected vX.Y.Z or vX.Y.Z-beta.N)"
             exit 1
           fi
           echo "Tag $TAG is valid"


### PR DESCRIPTION
## Summary

- Release workflow regex rejected valid semver pre-release tags like `v1.1.0-beta.1`
- Updated regex to accept `vX.Y.Z-{alpha,beta,rc}.N` in addition to `vX.Y.Z`

## Test plan
- [x] Merge, then re-run the `v1.1.0-beta.1` release