### PR TITLE
fix: stabilize TestAdaptiveAutoProtocol on slow CI runners

### DIFF
--- a/test/integration/adaptive_hybrid_test.go
+++ b/test/integration/adaptive_hybrid_test.go
@@ -35,8 +35,12 @@ func TestAdaptiveAutoProtocol(t *testing.T) {
 
 	addr := e.Addr().String()
 
-	// H1 requests.
-	h1Client := &http.Client{Timeout: 3 * time.Second}
+	// H1 requests. Use a dedicated transport to avoid reusing the readiness
+	// probe's pooled connection, which can be RST'd on slow CI machines.
+	h1Client := &http.Client{
+		Timeout:   3 * time.Second,
+		Transport: &http.Transport{},
+	}
 	for range 5 {
 		resp, err := h1Client.Get("http://" + addr + "/h1test")
 		if err != nil {

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -92,8 +92,12 @@ func startEngine(t *testing.T, e engine.Engine) {
 		}
 
 		// Readiness probe: verify the engine can serve a request.
+		// Use a non-pooling transport so the probe connection is closed
+		// immediately, preventing reuse by test clients (which would see
+		// RST on slow CI machines if the server recycles the connection).
 		addr := ag.Addr().String()
-		client := &http.Client{Timeout: 2 * time.Second}
+		probeTransport := &http.Transport{DisableKeepAlives: true}
+		client := &http.Client{Timeout: 2 * time.Second, Transport: probeTransport}
 		resp, probeErr := client.Get("http://" + addr + "/healthz")
 		if probeErr != nil {
 			cancel()


### PR DESCRIPTION
## Summary

- Fix flaky `TestAdaptiveAutoProtocol` that fails ~20% on Azure CI (2-vCPU runners)
- Root cause: readiness probe's keep-alive connection pooled via `http.DefaultTransport` gets RST'd by server between probe and first test request on slow machines
- Fix: `DisableKeepAlives: true` on probe transport + dedicated `http.Transport{}` for test client

## Evidence

| Environment | Before fix | After fix |
|------------|-----------|-----------|
| v1.1.0 (pre-merge) | 20/20 pass | — |
| v1.2.0 (post-merge) | ~16/20 pass | 20/20 pass |
| Azure CI (2-vCPU) | FAIL (triggered this PR) | Expected: PASS |

## Test plan

- [x] 20/20 pass in multipass VM (aarch64, 4 CPUs)
- [x] Full integration suite: 7/7 PASS
- [x] `go build ./...` clean
- [x] `go vet ./...` clean