### PR TITLE
feat: add celeristest.WithHandlers for middleware chain testing

### DIFF
--- a/celeristest/celeristest.go
+++ b/celeristest/celeristest.go
@@ -83,6 +83,7 @@ type config struct {
 	params     [][2]string
 	cookies    [][2]string
 	remoteAddr string
+	handlers   []any
 }
 
 // WithBody sets the request body.
@@ -126,6 +127,18 @@ func WithCookie(name, value string) Option {
 // WithRemoteAddr sets the remote address on the test stream.
 func WithRemoteAddr(addr string) Option {
 	return func(c *config) { c.remoteAddr = addr }
+}
+
+// WithHandlers sets the handler chain on the test context. This enables
+// middleware chain testing where mw1 calls c.Next() → mw2 runs → ... → final handler.
+// Pass celeris.HandlerFunc values; they are stored as []any to avoid import cycles.
+func WithHandlers(handlers ...celeris.HandlerFunc) Option {
+	return func(c *config) {
+		c.handlers = make([]any, len(handlers))
+		for i, h := range handlers {
+			c.handlers[i] = h
+		}
+	}
 }
 
 // ReleaseContext returns a [celeris.Context] to the pool. The context must not
@@ -190,6 +203,9 @@ func NewContext(method, path string, opts ...Option) (*celeris.Context, *Respons
 	ctx := ctxkit.NewContext(s).(*celeris.Context)
 	for _, p := range cfg.params {
 		ctxkit.AddParam(ctx, p[0], p[1])
+	}
+	if len(cfg.handlers) > 0 {
+		ctxkit.SetHandlers(ctx, cfg.handlers)
 	}
 	return ctx, rec
 }

--- a/context.go
+++ b/context.go
@@ -23,6 +23,15 @@ func init() {
 		ctx := c.(*Context)
 		ctx.params = append(ctx.params, Param{Key: key, Value: value})
 	}
+	ctxkit.SetHandlers = func(c any, handlers []any) {
+		ctx := c.(*Context)
+		chain := make([]HandlerFunc, len(handlers))
+		for i, h := range handlers {
+			chain[i] = h.(HandlerFunc)
+		}
+		ctx.handlers = chain
+		ctx.index = -1
+	}
 }
 
 // Context is the request context passed to handlers. It is pooled via sync.Pool.

--- a/internal/ctxkit/ctxkit.go
+++ b/internal/ctxkit/ctxkit.go
@@ -10,4 +10,5 @@ var (
 	NewContext     func(s *stream.Stream) any
 	ReleaseContext func(c any)
 	AddParam       func(c any, key, value string)
+	SetHandlers    func(c any, handlers []any)
 )


### PR DESCRIPTION
## Summary

- Add `celeristest.WithHandlers(...HandlerFunc)` option to set a handler chain on test contexts
- Add `ctxkit.SetHandlers` internal hook to bridge the type boundary
- Register `SetHandlers` in `context.go` init block

This enables the `goceleris/middlewares` v0.1.0 `testutil.RunChain` helper, which tests nested middleware (e.g. recovery wrapping a panicking handler, logger timing downstream).

Closes #139

## Changes

| File | Change |
|------|--------|
| `internal/ctxkit/ctxkit.go` | Add `SetHandlers func(c any, handlers []any)` hook |
| `context.go` | Register hook: converts `[]any` → `[]HandlerFunc`, sets on context |
| `celeristest/celeristest.go` | Add `handlers []any` to config, `WithHandlers` option, apply in `NewContext` |

## Test plan

- [x] `go test ./celeristest/...` passes
- [x] `go build ./...` passes
- [x] Verified via `goceleris/middlewares` testutil.RunChain — all 9 packages pass with `-race`