### PR TITLE
feat: v1.2.3 core-middleware integration

### DIFF
--- a/context.go
+++ b/context.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/goceleris/celeris/internal/ctxkit"
 	"github.com/goceleris/celeris/protocol/h2/stream"
@@ -68,6 +69,7 @@ type Context struct {
 	paramBuf   [4]Param
 	keys       map[string]any
 	ctx        context.Context
+	startTime  time.Time
 
 	method   string
 	path     string
@@ -109,12 +111,16 @@ type Context struct {
 	hostOverride     string
 
 	respHdrBuf [8][2]string // reusable buffer for response headers (avoids heap escape)
+
+	onRelease    []func()
+	onReleaseBuf [4]func()
 }
 
 var contextPool = sync.Pool{New: func() any {
 	c := &Context{keys: make(map[string]any, 4)}
 	c.params = c.paramBuf[:0]
 	c.respHeaders = c.respHdrBuf[:0]
+	c.onRelease = c.onReleaseBuf[:0]
 	return c
 }}
 
@@ -240,6 +246,11 @@ func (c *Context) SetContext(ctx context.Context) {
 	c.ctx = ctx
 }
 
+// StartTime returns the time at which request processing began. Set once by
+// the framework before the handler chain runs, so all middleware share the
+// same timestamp without calling time.Now() independently.
+func (c *Context) StartTime() time.Time { return c.startTime }
+
 // Set stores a key-value pair for this request.
 func (c *Context) Set(key string, value any) {
 	c.extended = true
@@ -265,7 +276,22 @@ func (c *Context) Keys() map[string]any {
 	return cp
 }
 
+// OnRelease registers a function to be called when this Context is released
+// back to the pool. Callbacks fire in LIFO order (like defer), before fields
+// are cleared, so context state is still accessible. Panics in callbacks are
+// recovered and silently discarded.
+func (c *Context) OnRelease(fn func()) {
+	c.extended = true
+	c.onRelease = append(c.onRelease, fn)
+}
+
 func (c *Context) reset() {
+	for i := len(c.onRelease) - 1; i >= 0; i-- {
+		func() {
+			defer func() { _ = recover() }()
+			c.onRelease[i]()
+		}()
+	}
 	c.stream = nil
 	c.index = -1
 	// Clear handler references so closures can be GCed, but only when
@@ -320,6 +346,10 @@ func (c *Context) reset() {
 		c.clientIPOverride = ""
 		c.schemeOverride = ""
 		c.hostOverride = ""
+		for i := range c.onRelease {
+			c.onRelease[i] = nil
+		}
+		c.onRelease = c.onReleaseBuf[:0]
 		c.extended = false
 	}
 }

--- a/context_request.go
+++ b/context_request.go
@@ -565,6 +565,15 @@ func (c *Context) IsTLS() bool {
 	return c.Scheme() == "https"
 }
 
+// Protocol returns the HTTP protocol version: "1.1" for HTTP/1.1 or "2"
+// for HTTP/2. Values match the OTel network.protocol.version convention.
+func (c *Context) Protocol() string {
+	if c.stream.ProtoMajor() == 1 {
+		return "1.1"
+	}
+	return "2"
+}
+
 // AcceptsEncodings returns the best matching encoding from the Accept-Encoding
 // header, or empty string if none match.
 func (c *Context) AcceptsEncodings(offers ...string) string {

--- a/context_request_test.go
+++ b/context_request_test.go
@@ -1519,3 +1519,35 @@ func TestFormValueOkDeprecated(t *testing.T) {
 		t.Fatal("expected missing field to return false")
 	}
 }
+
+func TestContextProtocolH2(t *testing.T) {
+	s, _ := newTestStream("GET", "/test")
+	defer s.Release()
+
+	c := acquireContext(s)
+	defer releaseContext(c)
+
+	if p := c.Protocol(); p != "2" {
+		t.Fatalf("expected \"2\" for default H2 stream, got %q", p)
+	}
+}
+
+func TestContextProtocolH1(t *testing.T) {
+	s := stream.NewH1Stream(1)
+	s.Headers = [][2]string{
+		{":method", "GET"},
+		{":path", "/test"},
+		{":scheme", "http"},
+		{":authority", "localhost"},
+	}
+	rw := &mockResponseWriter{}
+	s.ResponseWriter = rw
+	defer s.Release()
+
+	c := acquireContext(s)
+	defer releaseContext(c)
+
+	if p := c.Protocol(); p != "1.1" {
+		t.Fatalf("expected \"1.1\" for H1 stream, got %q", p)
+	}
+}

--- a/context_response.go
+++ b/context_response.go
@@ -555,6 +555,19 @@ func (c *Context) FlushResponse() error {
 	return c.Blob(c.capturedStatus, c.capturedType, c.capturedBody)
 }
 
+// DiscardBufferedResponse decrements the buffer depth and clears any captured
+// response data without writing to the wire. Used by timeout middleware to
+// discard a stale buffered response before writing an error response.
+func (c *Context) DiscardBufferedResponse() {
+	if c.bufferDepth > 0 {
+		c.bufferDepth--
+	}
+	c.buffered = false
+	c.capturedBody = c.capturedBody[:0]
+	c.capturedStatus = 0
+	c.capturedType = ""
+}
+
 // SetResponseBody replaces the buffered response body. Only valid after
 // BufferResponse + c.Next(). Used by transform middleware (compress, etc.).
 func (c *Context) SetResponseBody(body []byte) {

--- a/context_test.go
+++ b/context_test.go
@@ -309,6 +309,74 @@ func TestContextKeys(t *testing.T) {
 	}
 }
 
+func TestOnReleaseFiresOnRelease(t *testing.T) {
+	s, _ := newTestStream("GET", "/release")
+	defer s.Release()
+
+	c := acquireContext(s)
+	var fired bool
+	c.OnRelease(func() { fired = true })
+	releaseContext(c)
+
+	if !fired {
+		t.Fatal("expected OnRelease callback to fire during releaseContext")
+	}
+}
+
+func TestOnReleaseLIFOOrder(t *testing.T) {
+	s, _ := newTestStream("GET", "/lifo")
+	defer s.Release()
+
+	c := acquireContext(s)
+	var order []int
+	c.OnRelease(func() { order = append(order, 1) })
+	c.OnRelease(func() { order = append(order, 2) })
+	c.OnRelease(func() { order = append(order, 3) })
+	releaseContext(c)
+
+	if len(order) != 3 || order[0] != 3 || order[1] != 2 || order[2] != 1 {
+		t.Fatalf("expected LIFO order [3 2 1], got %v", order)
+	}
+}
+
+func TestOnReleasePanicRecovery(t *testing.T) {
+	s, _ := newTestStream("GET", "/panic-release")
+	defer s.Release()
+
+	c := acquireContext(s)
+	var normalFired bool
+	c.OnRelease(func() { normalFired = true })
+	c.OnRelease(func() { panic("boom") })
+	releaseContext(c)
+
+	if !normalFired {
+		t.Fatal("expected normal callback to fire even after panic in another")
+	}
+}
+
+func TestOnReleaseResetClearsCallbacks(t *testing.T) {
+	s, _ := newTestStream("GET", "/clear")
+	defer s.Release()
+
+	c := acquireContext(s)
+	callCount := 0
+	c.OnRelease(func() { callCount++ })
+	releaseContext(c)
+
+	if callCount != 1 {
+		t.Fatalf("expected 1 call, got %d", callCount)
+	}
+
+	// Re-acquire and release again without registering new callbacks.
+	// The callback must NOT fire a second time.
+	c2 := acquireContext(s)
+	releaseContext(c2)
+
+	if callCount != 1 {
+		t.Fatalf("expected callback count to remain 1 after reuse, got %d", callCount)
+	}
+}
+
 func TestHandleUnmatchedFallback(t *testing.T) {
 	// Custom 404 handler that returns nil without writing should fall back
 	// to default response.
@@ -327,5 +395,24 @@ func TestHandleUnmatchedFallback(t *testing.T) {
 
 	if rw.status != 404 {
 		t.Fatalf("expected 404 fallback response, got %d", rw.status)
+	}
+}
+
+func TestContextStartTime(t *testing.T) {
+	s, _ := newTestStream("GET", "/test")
+	defer s.Release()
+
+	before := time.Now()
+	c := acquireContext(s)
+	c.startTime = time.Now()
+	after := time.Now()
+	defer releaseContext(c)
+
+	st := c.StartTime()
+	if st.IsZero() {
+		t.Fatal("expected non-zero StartTime")
+	}
+	if st.Before(before) || st.After(after) {
+		t.Fatalf("StartTime %v not within bracket [%v, %v]", st, before, after)
 	}
 }

--- a/doc.go
+++ b/doc.go
@@ -52,9 +52,8 @@
 //
 //	func timing() celeris.HandlerFunc {
 //	    return func(c *celeris.Context) error {
-//	        start := time.Now()
 //	        err := c.Next()
-//	        elapsed := time.Since(start)
+//	        elapsed := time.Since(c.StartTime())
 //	        c.SetHeader("x-response-time", elapsed.String())
 //	        return err
 //	    }
@@ -83,6 +82,27 @@
 //	    }
 //	    return nil
 //	})
+//
+// # Global Error Handler
+//
+// Register a global error handler with Server.OnError. This is called when
+// an unhandled error reaches the safety net after all middleware has had its
+// chance. Use it to render structured error responses (e.g. JSON) instead of
+// the default text/plain fallback:
+//
+//	s.OnError(func(c *celeris.Context, err error) {
+//	    var he *celeris.HTTPError
+//	    code := 500
+//	    msg := "internal server error"
+//	    if errors.As(err, &he) {
+//	        code = he.Code
+//	        msg = he.Message
+//	    }
+//	    c.JSON(code, map[string]string{"error": msg})
+//	})
+//
+// If the handler does not write a response, the default text/plain fallback
+// applies. OnError must be called before Start.
 //
 // # Custom 404 / 405 Handlers
 //

--- a/engine/std/bridge.go
+++ b/engine/std/bridge.go
@@ -79,6 +79,7 @@ func (b *Bridge) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.RemoteAddr = r.RemoteAddr
+	s.SetProtoMajor(uint8(r.ProtoMajor))
 	s.EndStream = true
 	s.SetState(stream.StateHalfClosedRemote)
 

--- a/handler.go
+++ b/handler.go
@@ -15,15 +15,12 @@ type routerAdapter struct {
 	server                *Server
 	notFoundChain         []HandlerFunc
 	methodNotAllowedChain []HandlerFunc
+	errorHandler          func(*Context, error)
 }
 
 func (a *routerAdapter) HandleStream(_ context.Context, s *stream.Stream) error {
-	var start time.Time
-	if a.server.collector != nil {
-		start = time.Now()
-	}
-
 	c := acquireContext(s)
+	c.startTime = time.Now()
 
 	if a.server.config.MaxFormSize != 0 {
 		c.maxFormSize = a.server.config.MaxFormSize
@@ -35,7 +32,7 @@ func (a *routerAdapter) HandleStream(_ context.Context, s *stream.Stream) error 
 
 	handlers, fullPath := a.server.router.find(c.method, c.path, &c.params)
 
-	defer a.recoverAndRelease(c, s, start)
+	defer a.recoverAndRelease(c, s)
 
 	if handlers == nil {
 		a.handleUnmatched(c, s)
@@ -60,7 +57,7 @@ func (a *routerAdapter) HandleStream(_ context.Context, s *stream.Stream) error 
 // by the deferred closure and debug.Stack() call (P5).
 //
 //go:noinline
-func (a *routerAdapter) recoverAndRelease(c *Context, s *stream.Stream, start time.Time) {
+func (a *routerAdapter) recoverAndRelease(c *Context, s *stream.Stream) {
 	if r := recover(); r != nil {
 		a.handlePanic(c, s, r)
 	}
@@ -72,7 +69,7 @@ func (a *routerAdapter) recoverAndRelease(c *Context, s *stream.Stream, start ti
 				if status == 0 {
 					status = 200
 				}
-				a.server.collector.RecordRequest(time.Since(start), status)
+				a.server.collector.RecordRequest(time.Since(c.startTime), status)
 			}
 			releaseContext(c)
 		}()
@@ -83,7 +80,7 @@ func (a *routerAdapter) recoverAndRelease(c *Context, s *stream.Stream, start ti
 		if status == 0 {
 			status = 200
 		}
-		a.server.collector.RecordRequest(time.Since(start), status)
+		a.server.collector.RecordRequest(time.Since(c.startTime), status)
 	}
 	releaseContext(c)
 }
@@ -151,6 +148,12 @@ func (a *routerAdapter) handleUnmatched(c *Context, s *stream.Stream) {
 func (a *routerAdapter) handleError(c *Context, s *stream.Stream, err error) {
 	if err == nil || c.written {
 		return
+	}
+	if a.errorHandler != nil {
+		a.errorHandler(c, err)
+		if c.written {
+			return
+		}
 	}
 	var he *HTTPError
 	if errors.As(err, &he) {

--- a/protocol/h2/stream/stream.go
+++ b/protocol/h2/stream/stream.go
@@ -55,7 +55,8 @@ type Stream struct {
 	ReceivedInitialHeaders bool
 	ClosedByReset          bool
 	IsHEAD                 bool
-	h1Mode                 bool // single-threaded H1 stream; skip mutex in GetHeaders
+	h1Mode                 bool  // single-threaded H1 stream; skip mutex in GetHeaders
+	protoMajor             uint8 // 0=infer from h1Mode, 1=HTTP/1.1, 2=HTTP/2
 	flags                  atomic.Uint32
 	doneCh                 atomic.Pointer[chan struct{}]
 	phase                  Phase
@@ -130,6 +131,20 @@ func (s *Stream) GetBuf() *bytes.Buffer {
 
 // IsH1 returns true if this is an H1 stream (single-threaded, persistent per connection).
 func (s *Stream) IsH1() bool { return s.h1Mode }
+
+// ProtoMajor returns the HTTP major version (1 or 2).
+func (s *Stream) ProtoMajor() uint8 {
+	if s.protoMajor != 0 {
+		return s.protoMajor
+	}
+	if s.h1Mode {
+		return 1
+	}
+	return 2
+}
+
+// SetProtoMajor sets the HTTP major version explicitly.
+func (s *Stream) SetProtoMajor(v uint8) { s.protoMajor = v }
 
 // Context returns the stream's context.
 func (s *Stream) Context() context.Context {
@@ -213,6 +228,7 @@ func (s *Stream) resetAndPool() {
 	s.ClosedByReset = false
 	s.IsHEAD = false
 	s.h1Mode = false
+	s.protoMajor = 0
 	s.flags.Store(0)
 	s.doneCh.Store(nil)
 	s.phase = 0
@@ -273,6 +289,7 @@ func ResetH2StreamInline(s *Stream, id uint32) {
 	s.ClosedByReset = false
 	s.IsHEAD = false
 	s.h1Mode = false
+	s.protoMajor = 0
 	s.flags.Store(0)
 	s.doneCh.Store(nil)
 	s.phase = PhaseInit

--- a/server.go
+++ b/server.go
@@ -55,6 +55,7 @@ type Server struct {
 
 	notFoundHandler         HandlerFunc
 	methodNotAllowedHandler HandlerFunc
+	errorHandler            func(*Context, error)
 
 	startOnce sync.Once
 	startErr  error
@@ -143,6 +144,15 @@ func (s *Server) NotFound(handler HandlerFunc) *Server {
 // but the HTTP method does not. The Allow header is set automatically.
 func (s *Server) MethodNotAllowed(handler HandlerFunc) *Server {
 	s.methodNotAllowedHandler = handler
+	return s
+}
+
+// OnError registers a global error handler called when an unhandled error
+// reaches the safety net after all middleware has had its chance. The handler
+// should write a response. If it does not write, the default text/plain
+// fallback applies. Must be called before Start.
+func (s *Server) OnError(handler func(c *Context, err error)) *Server {
+	s.errorHandler = handler
 	return s
 }
 
@@ -382,6 +392,7 @@ func (s *Server) doPrepare(configureFn func(cfg *resource.Config)) (engine.Engin
 		if s.methodNotAllowedHandler != nil {
 			ra.methodNotAllowedChain = []HandlerFunc{s.methodNotAllowedHandler}
 		}
+		ra.errorHandler = s.errorHandler
 		var handler stream.Handler = ra
 		var err error
 		eng, err = createEngine(cfg, handler)

--- a/server_test.go
+++ b/server_test.go
@@ -1314,3 +1314,87 @@ func TestPauseAcceptNotStarted(t *testing.T) {
 		t.Fatalf("expected ErrAcceptControlNotSupported, got %v", err)
 	}
 }
+
+func TestServerOnErrorHTTPError(t *testing.T) {
+	s := New(Config{})
+	s.OnError(func(c *Context, err error) {
+		var he *HTTPError
+		code := 500
+		msg := "internal"
+		if errors.As(err, &he) {
+			code = he.Code
+			msg = he.Message
+		}
+		_ = c.JSON(code, map[string]string{"error": msg})
+	})
+	s.GET("/fail", func(_ *Context) error {
+		return NewHTTPError(422, "validation failed")
+	})
+
+	adapter := &routerAdapter{server: s, errorHandler: s.errorHandler}
+
+	st, rw := newTestStream("GET", "/fail")
+	if err := adapter.HandleStream(context.Background(), st); err != nil {
+		t.Fatal(err)
+	}
+	if rw.status != 422 {
+		t.Fatalf("expected 422, got %d", rw.status)
+	}
+	if !contains(rw.body, "validation failed") {
+		t.Fatalf("expected JSON with 'validation failed', got %s", string(rw.body))
+	}
+	st.Release()
+}
+
+func TestServerOnErrorNilHandler(t *testing.T) {
+	s := New(Config{})
+	s.GET("/fail", func(_ *Context) error {
+		return NewHTTPError(400, "bad request")
+	})
+
+	adapter := &routerAdapter{server: s}
+
+	st, rw := newTestStream("GET", "/fail")
+	if err := adapter.HandleStream(context.Background(), st); err != nil {
+		t.Fatal(err)
+	}
+	if rw.status != 400 {
+		t.Fatalf("expected 400, got %d", rw.status)
+	}
+	if string(rw.body) != "bad request" {
+		t.Fatalf("expected text/plain 'bad request', got %q", string(rw.body))
+	}
+	st.Release()
+}
+
+func TestServerOnErrorNoWrite(t *testing.T) {
+	s := New(Config{})
+	s.OnError(func(_ *Context, _ error) {
+		// Deliberately do nothing — default fallback should apply.
+	})
+	s.GET("/fail", func(_ *Context) error {
+		return fmt.Errorf("something broke")
+	})
+
+	adapter := &routerAdapter{server: s, errorHandler: s.errorHandler}
+
+	st, rw := newTestStream("GET", "/fail")
+	if err := adapter.HandleStream(context.Background(), st); err != nil {
+		t.Fatal(err)
+	}
+	if rw.status != 500 {
+		t.Fatalf("expected 500 fallback, got %d", rw.status)
+	}
+	if string(rw.body) != "Internal Server Error" {
+		t.Fatalf("expected 'Internal Server Error' fallback, got %q", string(rw.body))
+	}
+	st.Release()
+}
+
+func TestServerOnErrorChaining(t *testing.T) {
+	s := New(Config{})
+	result := s.OnError(func(_ *Context, _ error) {})
+	if result != s {
+		t.Fatal("expected OnError to return *Server for chaining")
+	}
+}

--- a/stdlib.go
+++ b/stdlib.go
@@ -62,6 +62,7 @@ func ToHandler(h HandlerFunc) http.Handler {
 		}
 
 		s.RemoteAddr = r.RemoteAddr
+		s.SetProtoMajor(uint8(r.ProtoMajor))
 		s.EndStream = true
 		s.SetState(stream.StateHalfClosedRemote)
 


### PR DESCRIPTION
## Summary

Four new APIs that tighten the symbiosis between celeris core and the middleware ecosystem:

- **`Context.Protocol()`** — returns `"1.1"` or `"2"` via `stream.ProtoMajor()`. Fixes OTel's broken `:protocol` pseudo-header heuristic that tagged all H2 traffic as "1.1". Zero-cost: one byte read + comparison.
- **`Context.StartTime()`** — shared request timestamp set once in `HandleStream()` before the handler chain. Eliminates 2-3 redundant `time.Now()` calls per request across logger/metrics/otel middleware. Removes `start` parameter from `recoverAndRelease`.
- **`Context.OnRelease(fn func())`** — LIFO cleanup callbacks with `[4]func()` inline buffer (zero-alloc for ≤4 callbacks). Panic-safe with per-callback recovery. Eliminates the session middleware's pool leak class (manual `returnToPool()` on every exit path → single `c.OnRelease()`).
- **`Server.OnError(fn func(c *Context, err error))`** — global error handler hook in `handleError()` before the default text/plain fallback. Enables JSON error responses without configuring each middleware individually. Wired in `doPrepare()`, panic-safe via existing recovery.

- Closes #148
- Closes #149
- Closes #150
- Closes #151
- Closes #152

## Files changed (12 files, +320/-12)

| File | Changes |
|------|---------|
| `protocol/h2/stream/stream.go` | `protoMajor uint8` field + `ProtoMajor()`/`SetProtoMajor()` methods |
| `context_request.go` | `Protocol()` method |
| `engine/std/bridge.go` | Set `protoMajor` from `r.ProtoMajor` |
| `stdlib.go` | Set `protoMajor` from `r.ProtoMajor` in `ToHandler` |
| `context.go` | `startTime`, `onRelease`/`onReleaseBuf` fields + `StartTime()`, `OnRelease()` methods + reset logic |
| `handler.go` | Unconditional `time.Now()`, removed `start` param, `errorHandler` field + call in `handleError` |
| `server.go` | `errorHandler` field + `OnError()` method + wiring in `doPrepare()` |
| `doc.go` | Updated timing example, added Global Error Handler section |
| `context_test.go` | 5 tests: StartTime, OnRelease (fires, LIFO, panic recovery, reset clears) |
| `context_request_test.go` | 2 tests: Protocol H1 + H2 |
| `server_test.go` | 4 tests: OnError (HTTPError, nil handler, no-write fallback, chaining) |

## Middleware consumers (separate PR in goceleris/middlewares)

| Middleware | Integration |
|-----------|-------------|
| otel | `c.Protocol()` restores `network.protocol.version`; `c.StartTime()` replaces `time.Now()` |
| logger | `c.StartTime()` replaces `time.Now()`; CLFConfig uses `c.StartTime().UTC()` |
| metrics | `c.StartTime()` replaces `time.Now()` |
| session | `c.OnRelease(returnToPool)` replaces 3 manual cleanup calls |
| requestid | SkipPaths exact match (fixes #151 inconsistency) |

## Test plan

- [x] `go test -race -count=1 ./...` passes (all new + existing tests)
- [x] `golangci-lint run` — 0 issues
- [x] `go build ./...` — clean
- [x] Cherry-picked cleanly onto `origin/main` — no merge conflicts
- [ ] Middleware tests pass after `go.mod` updated to v1.2.3