### PR TITLE
feat: v1.3.2 resilience middleware — singleflight, circuitbreaker

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ All middleware is in-tree under [`middleware/`](middleware/):
 | [`basicauth`](middleware/basicauth) | HTTP Basic authentication with hashed password support |
 | [`bodylimit`](middleware/bodylimit) | Request body size enforcement |
 | [`compress`](middleware/compress) | Response compression (zstd, brotli, gzip; separate go.mod) |
+| [`circuitbreaker`](middleware/circuitbreaker) | Circuit breaker (3-state, sliding window error rate, 503 + Retry-After) |
 | [`cors`](middleware/cors) | Cross-Origin Resource Sharing (zero-alloc) |
 | [`csrf`](middleware/csrf) | CSRF protection (double-submit cookie + origin validation) |
 | [`debug`](middleware/debug) | Debug/introspection endpoints (loopback-only by default) |
@@ -122,6 +123,7 @@ All middleware is in-tree under [`middleware/`](middleware/):
 | [`requestid`](middleware/requestid) | Request ID generation (buffered UUID v4) |
 | [`secure`](middleware/secure) | Security headers (HSTS, CSP, COOP/CORP/COEP, OWASP defaults) |
 | [`session`](middleware/session) | Cookie-based sessions with pluggable store |
+| [`singleflight`](middleware/singleflight) | Request coalescing (collapse identical in-flight requests) |
 | [`timeout`](middleware/timeout) | Request timeout with cooperative and preemptive modes |
 
 ```go
@@ -277,7 +279,7 @@ adaptive/       Adaptive meta-engine (Linux)
 celeristest/    Test helpers (NewContext, ResponseRecorder)
 engine/         Engine interface + implementations (iouring, epoll, std)
 internal/       Shared internals (conn, cpumon, ctxkit, negotiate, platform, sockopts)
-middleware/     In-tree middleware ecosystem (22 packages)
+middleware/     In-tree middleware ecosystem (24 packages)
 observe/        Metrics collector, CPUMonitor, Snapshot
 probe/          System capability detection
 protocol/       Protocol parsers (h1, h2, detect)

--- a/middleware/bench_chain_test.go
+++ b/middleware/bench_chain_test.go
@@ -10,9 +10,11 @@ import (
 
 	"github.com/goceleris/celeris"
 	"github.com/goceleris/celeris/celeristest"
+	"github.com/goceleris/celeris/middleware/circuitbreaker"
 	"github.com/goceleris/celeris/middleware/cors"
 	"github.com/goceleris/celeris/middleware/etag"
 	"github.com/goceleris/celeris/middleware/methodoverride"
+	"github.com/goceleris/celeris/middleware/singleflight"
 	"github.com/goceleris/celeris/middleware/proxy"
 	"github.com/goceleris/celeris/middleware/ratelimit"
 	"github.com/goceleris/celeris/middleware/recovery"
@@ -487,6 +489,44 @@ func BenchmarkChainETagHit(b *testing.B) {
 	b.ResetTimer()
 	for b.Loop() {
 		ctx, _ := celeristest.NewContext("GET", "/api/users", opts...)
+		_ = ctx.Next()
+		celeristest.ReleaseContext(ctx)
+	}
+}
+
+// BenchmarkChainWithCircuitBreaker benchmarks: requestid -> recovery -> circuitbreaker -> timeout -> handler.
+func BenchmarkChainWithCircuitBreaker(b *testing.B) {
+	chain := []celeris.HandlerFunc{
+		requestid.New(),
+		recovery.New(recovery.Config{DisableLogStack: true}),
+		circuitbreaker.New(),
+		timeout.New(timeout.Config{Timeout: 30 * time.Second}),
+		jsonHandler,
+	}
+	opts := []celeristest.Option{celeristest.WithHandlers(chain...)}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		ctx, _ := celeristest.NewContext("GET", "/api/users", opts...)
+		_ = ctx.Next()
+		celeristest.ReleaseContext(ctx)
+	}
+}
+
+// BenchmarkChainWithSingleflight benchmarks: requestid -> recovery -> singleflight -> etag -> handler.
+func BenchmarkChainWithSingleflight(b *testing.B) {
+	chain := []celeris.HandlerFunc{
+		requestid.New(),
+		recovery.New(recovery.Config{DisableLogStack: true}),
+		singleflight.New(),
+		etag.New(),
+		textHandler,
+	}
+	opts := []celeristest.Option{celeristest.WithHandlers(chain...)}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		ctx, _ := celeristest.NewContext("GET", "/api/data", opts...)
 		_ = ctx.Next()
 		celeristest.ReleaseContext(ctx)
 	}

--- a/middleware/bench_chain_test.go
+++ b/middleware/bench_chain_test.go
@@ -14,13 +14,13 @@ import (
 	"github.com/goceleris/celeris/middleware/cors"
 	"github.com/goceleris/celeris/middleware/etag"
 	"github.com/goceleris/celeris/middleware/methodoverride"
-	"github.com/goceleris/celeris/middleware/singleflight"
 	"github.com/goceleris/celeris/middleware/proxy"
 	"github.com/goceleris/celeris/middleware/ratelimit"
 	"github.com/goceleris/celeris/middleware/recovery"
 	"github.com/goceleris/celeris/middleware/redirect"
 	"github.com/goceleris/celeris/middleware/requestid"
 	"github.com/goceleris/celeris/middleware/secure"
+	"github.com/goceleris/celeris/middleware/singleflight"
 	"github.com/goceleris/celeris/middleware/timeout"
 )
 

--- a/middleware/circuitbreaker/bench_test.go
+++ b/middleware/circuitbreaker/bench_test.go
@@ -1,0 +1,69 @@
+package circuitbreaker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/goceleris/celeris"
+	"github.com/goceleris/celeris/celeristest"
+)
+
+func BenchmarkCircuitBreakerClosed(b *testing.B) {
+	mw := New(Config{
+		Threshold:   0.5,
+		MinRequests: 1_000_000,
+		WindowSize:  time.Hour,
+	})
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		c, _ := celeristest.NewContext("GET", "/")
+		_ = mw(c)
+		celeristest.ReleaseContext(c)
+	}
+}
+
+func BenchmarkCircuitBreakerOpen(b *testing.B) {
+	mw, _ := NewWithBreaker(Config{
+		Threshold:      0.5,
+		MinRequests:    2,
+		WindowSize:     time.Hour,
+		CooldownPeriod: time.Hour,
+	})
+
+	// Trip the breaker.
+	for range 2 {
+		handler := func(c *celeris.Context) error {
+			return celeris.NewHTTPError(500, "fail")
+		}
+		c, _ := celeristest.NewContext("GET", "/",
+			celeristest.WithHandlers(mw, handler))
+		_ = c.Next()
+		celeristest.ReleaseContext(c)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		c, _ := celeristest.NewContext("GET", "/")
+		_ = mw(c)
+		celeristest.ReleaseContext(c)
+	}
+}
+
+func BenchmarkCircuitBreakerParallel(b *testing.B) {
+	mw := New(Config{
+		Threshold:   0.5,
+		MinRequests: 1_000_000,
+		WindowSize:  time.Hour,
+	})
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			c, _ := celeristest.NewContext("GET", "/")
+			_ = mw(c)
+			celeristest.ReleaseContext(c)
+		}
+	})
+}

--- a/middleware/circuitbreaker/circuitbreaker.go
+++ b/middleware/circuitbreaker/circuitbreaker.go
@@ -1,0 +1,198 @@
+package circuitbreaker
+
+import (
+	"errors"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/goceleris/celeris"
+)
+
+// Breaker holds the circuit breaker state. Use [NewWithBreaker] to obtain
+// a reference for programmatic state inspection and reset.
+type Breaker struct {
+	state        atomic.Int32
+	openedAt     atomic.Int64  // UnixNano when breaker opened
+	halfOpenUsed atomic.Int32  // probe requests admitted in half-open
+	mu           sync.Mutex    // protects state transitions
+	window       *slidingWindow
+
+	threshold      float64
+	minRequests    int
+	cooldownPeriod int64 // nanoseconds
+	halfOpenMax    int32
+	isError        func(err error, statusCode int) bool
+	onStateChange  func(from, to State)
+}
+
+// State returns the current circuit breaker state.
+func (b *Breaker) State() State {
+	return State(b.state.Load())
+}
+
+// Reset forces the breaker back to Closed and clears the observation window.
+func (b *Breaker) Reset() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	from := State(b.state.Load())
+	b.state.Store(int32(Closed))
+	b.halfOpenUsed.Store(0)
+	b.window.reset()
+	if from != Closed && b.onStateChange != nil {
+		b.onStateChange(from, Closed)
+	}
+}
+
+// New creates a circuit breaker middleware with the given config.
+func New(config ...Config) celeris.HandlerFunc {
+	mw, _ := NewWithBreaker(config...)
+	return mw
+}
+
+// NewWithBreaker creates a circuit breaker middleware and returns both
+// the handler and the underlying [Breaker] for programmatic access.
+func NewWithBreaker(config ...Config) (celeris.HandlerFunc, *Breaker) {
+	cfg := defaultConfig
+	if len(config) > 0 {
+		cfg = config[0]
+	}
+	cfg = applyDefaults(cfg)
+	validate(cfg)
+
+	var skip celeris.SkipHelper
+	skip.Init(cfg.SkipPaths, cfg.Skip)
+
+	brk := &Breaker{
+		window:         newSlidingWindow(cfg.WindowSize),
+		threshold:      cfg.Threshold,
+		minRequests:    cfg.MinRequests,
+		cooldownPeriod: int64(cfg.CooldownPeriod),
+		halfOpenMax:    int32(cfg.HalfOpenMax),
+		isError:        cfg.IsError,
+		onStateChange:  cfg.OnStateChange,
+	}
+
+	errHandler := cfg.ErrorHandler
+
+	handler := func(c *celeris.Context) error {
+		if skip.ShouldSkip(c) {
+			return c.Next()
+		}
+
+		now := time.Now().UnixNano()
+		st := State(brk.state.Load())
+
+		switch st {
+		case Open:
+			if now-brk.openedAt.Load() >= brk.cooldownPeriod {
+				brk.mu.Lock()
+				// Double-check under lock.
+				if State(brk.state.Load()) == Open && now-brk.openedAt.Load() >= brk.cooldownPeriod {
+					brk.state.Store(int32(HalfOpen))
+					brk.halfOpenUsed.Store(0)
+					if brk.onStateChange != nil {
+						brk.onStateChange(Open, HalfOpen)
+					}
+					st = HalfOpen
+				} else {
+					st = State(brk.state.Load())
+				}
+				brk.mu.Unlock()
+			}
+			if st == Open {
+				retryAfter := (brk.cooldownPeriod - (now - brk.openedAt.Load())) / int64(time.Second)
+				if retryAfter < 1 {
+					retryAfter = 1
+				}
+				c.SetHeader("retry-after", strconv.FormatInt(retryAfter, 10))
+				return errHandler(c, ErrServiceUnavailable)
+			}
+			// Fell through to HalfOpen.
+			fallthrough
+
+		case HalfOpen:
+			used := brk.halfOpenUsed.Add(1)
+			if used > brk.halfOpenMax {
+				retryAfter := int64(1)
+				c.SetHeader("retry-after", strconv.FormatInt(retryAfter, 10))
+				return errHandler(c, ErrServiceUnavailable)
+			}
+
+		case Closed:
+			// Let through.
+		}
+
+		err := c.Next()
+
+		status := responseStatus(c, err)
+		isFailure := brk.isError(err, status)
+
+		if isFailure {
+			brk.window.recordFailure()
+		} else {
+			brk.window.recordSuccess()
+		}
+
+		currentState := State(brk.state.Load())
+		switch currentState {
+		case Closed:
+			total, failures := brk.window.counts()
+			if total >= int64(brk.minRequests) && float64(failures)/float64(total) >= brk.threshold {
+				brk.mu.Lock()
+				// Double-check under lock.
+				if State(brk.state.Load()) == Closed {
+					brk.state.Store(int32(Open))
+					brk.openedAt.Store(time.Now().UnixNano())
+					brk.window.reset()
+					if brk.onStateChange != nil {
+						brk.onStateChange(Closed, Open)
+					}
+				}
+				brk.mu.Unlock()
+			}
+
+		case HalfOpen:
+			brk.mu.Lock()
+			if State(brk.state.Load()) == HalfOpen {
+				if isFailure {
+					brk.state.Store(int32(Open))
+					brk.openedAt.Store(time.Now().UnixNano())
+					brk.halfOpenUsed.Store(0)
+					brk.window.reset()
+					if brk.onStateChange != nil {
+						brk.onStateChange(HalfOpen, Open)
+					}
+				} else {
+					brk.state.Store(int32(Closed))
+					brk.halfOpenUsed.Store(0)
+					brk.window.reset()
+					if brk.onStateChange != nil {
+						brk.onStateChange(HalfOpen, Closed)
+					}
+				}
+			}
+			brk.mu.Unlock()
+		}
+
+		return err
+	}
+
+	return handler, brk
+}
+
+// responseStatus derives the HTTP status code from the error or context.
+func responseStatus(c *celeris.Context, err error) int {
+	if err != nil {
+		var he *celeris.HTTPError
+		if errors.As(err, &he) {
+			return he.Code
+		}
+		return 500
+	}
+	if status := c.StatusCode(); status != 0 {
+		return status
+	}
+	return 200
+}

--- a/middleware/circuitbreaker/circuitbreaker.go
+++ b/middleware/circuitbreaker/circuitbreaker.go
@@ -14,9 +14,9 @@ import (
 // a reference for programmatic state inspection and reset.
 type Breaker struct {
 	state        atomic.Int32
-	openedAt     atomic.Int64  // UnixNano when breaker opened
-	halfOpenUsed atomic.Int32  // probe requests admitted in half-open
-	mu           sync.Mutex    // protects state transitions
+	openedAt     atomic.Int64 // UnixNano when breaker opened
+	halfOpenUsed atomic.Int32 // probe requests admitted in half-open
+	mu           sync.Mutex   // protects state transitions
 	window       *slidingWindow
 
 	threshold      float64

--- a/middleware/circuitbreaker/circuitbreaker_test.go
+++ b/middleware/circuitbreaker/circuitbreaker_test.go
@@ -1,0 +1,510 @@
+package circuitbreaker
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/goceleris/celeris"
+	"github.com/goceleris/celeris/celeristest"
+	"github.com/goceleris/celeris/middleware/internal/testutil"
+)
+
+func okHandler(c *celeris.Context) error {
+	return c.String(200, "ok")
+}
+
+func errHandler500(c *celeris.Context) error {
+	return celeris.NewHTTPError(500, "Internal Server Error")
+}
+
+// tripBreaker sends MinRequests failing requests to trip the breaker.
+func tripBreaker(t *testing.T, mw celeris.HandlerFunc, minReqs int) {
+	t.Helper()
+	chain := []celeris.HandlerFunc{mw, errHandler500}
+	for range minReqs {
+		_, _ = testutil.RunChain(t, chain, "GET", "/")
+	}
+}
+
+func TestClosedPassesThrough(t *testing.T) {
+	mw := New(Config{
+		Threshold:   0.5,
+		MinRequests: 10,
+		WindowSize:  100 * time.Millisecond,
+	})
+	chain := []celeris.HandlerFunc{mw, okHandler}
+	rec, err := testutil.RunChain(t, chain, "GET", "/")
+	testutil.AssertNoError(t, err)
+	testutil.AssertStatus(t, rec, 200)
+	testutil.AssertBodyContains(t, rec, "ok")
+}
+
+func TestErrorRateBelowThresholdStaysClosed(t *testing.T) {
+	mw, brk := NewWithBreaker(Config{
+		Threshold:   0.5,
+		MinRequests: 10,
+		WindowSize:  1 * time.Second,
+	})
+
+	successChain := []celeris.HandlerFunc{mw, okHandler}
+	failChain := []celeris.HandlerFunc{mw, errHandler500}
+
+	// 8 successes, 2 failures = 20% error rate (below 50%).
+	for range 8 {
+		_, err := testutil.RunChain(t, successChain, "GET", "/")
+		testutil.AssertNoError(t, err)
+	}
+	for range 2 {
+		_, _ = testutil.RunChain(t, failChain, "GET", "/")
+	}
+
+	if brk.State() != Closed {
+		t.Fatalf("expected Closed, got %s", brk.State())
+	}
+}
+
+func TestErrorRateAtThresholdTripsOpen(t *testing.T) {
+	mw, brk := NewWithBreaker(Config{
+		Threshold:      0.5,
+		MinRequests:    2,
+		WindowSize:     1 * time.Second,
+		CooldownPeriod: 10 * time.Second,
+	})
+
+	failChain := []celeris.HandlerFunc{mw, errHandler500}
+	for range 2 {
+		_, _ = testutil.RunChain(t, failChain, "GET", "/")
+	}
+
+	if brk.State() != Open {
+		t.Fatalf("expected Open, got %s", brk.State())
+	}
+}
+
+func TestOpenReturns503(t *testing.T) {
+	mw, _ := NewWithBreaker(Config{
+		Threshold:      0.5,
+		MinRequests:    2,
+		WindowSize:     1 * time.Second,
+		CooldownPeriod: 10 * time.Second,
+	})
+
+	tripBreaker(t, mw, 2)
+
+	// Next request should be rejected.
+	_, err := testutil.RunMiddleware(t, mw)
+	testutil.AssertHTTPError(t, err, 503)
+}
+
+func TestOpenSetsRetryAfterHeader(t *testing.T) {
+	mw, _ := NewWithBreaker(Config{
+		Threshold:      0.5,
+		MinRequests:    2,
+		WindowSize:     1 * time.Second,
+		CooldownPeriod: 10 * time.Second,
+	})
+
+	tripBreaker(t, mw, 2)
+
+	chain := []celeris.HandlerFunc{mw, okHandler}
+	ctx, _ := celeristest.NewContextT(t, "GET", "/",
+		celeristest.WithHandlers(chain...))
+	_ = ctx.Next()
+
+	// The retry-after header is set on the context's response headers,
+	// not written to the recorder (since the error short-circuits).
+	var found bool
+	for _, h := range ctx.ResponseHeaders() {
+		if h[0] == "retry-after" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("retry-after header missing from response headers")
+	}
+}
+
+func TestOpenToHalfOpenAfterCooldown(t *testing.T) {
+	mw, brk := NewWithBreaker(Config{
+		Threshold:      0.5,
+		MinRequests:    2,
+		WindowSize:     100 * time.Millisecond,
+		CooldownPeriod: 50 * time.Millisecond,
+		HalfOpenMax:    1,
+	})
+
+	tripBreaker(t, mw, 2)
+
+	if brk.State() != Open {
+		t.Fatalf("expected Open, got %s", brk.State())
+	}
+
+	time.Sleep(60 * time.Millisecond)
+
+	// Next request should transition to half-open and pass through.
+	chain := []celeris.HandlerFunc{mw, okHandler}
+	rec, err := testutil.RunChain(t, chain, "GET", "/")
+	testutil.AssertNoError(t, err)
+	testutil.AssertStatus(t, rec, 200)
+
+	if brk.State() != Closed {
+		t.Fatalf("expected Closed after successful probe, got %s", brk.State())
+	}
+}
+
+func TestHalfOpenSuccessToClosed(t *testing.T) {
+	mw, brk := NewWithBreaker(Config{
+		Threshold:      0.5,
+		MinRequests:    2,
+		WindowSize:     100 * time.Millisecond,
+		CooldownPeriod: 50 * time.Millisecond,
+		HalfOpenMax:    1,
+	})
+
+	tripBreaker(t, mw, 2)
+	time.Sleep(60 * time.Millisecond)
+
+	chain := []celeris.HandlerFunc{mw, okHandler}
+	_, err := testutil.RunChain(t, chain, "GET", "/")
+	testutil.AssertNoError(t, err)
+
+	if brk.State() != Closed {
+		t.Fatalf("expected Closed, got %s", brk.State())
+	}
+}
+
+func TestHalfOpenFailureToOpen(t *testing.T) {
+	mw, brk := NewWithBreaker(Config{
+		Threshold:      0.5,
+		MinRequests:    2,
+		WindowSize:     100 * time.Millisecond,
+		CooldownPeriod: 50 * time.Millisecond,
+		HalfOpenMax:    1,
+	})
+
+	tripBreaker(t, mw, 2)
+	time.Sleep(60 * time.Millisecond)
+
+	chain := []celeris.HandlerFunc{mw, errHandler500}
+	_, _ = testutil.RunChain(t, chain, "GET", "/")
+
+	if brk.State() != Open {
+		t.Fatalf("expected Open, got %s", brk.State())
+	}
+}
+
+func TestHalfOpenLimitsConcurrent(t *testing.T) {
+	mw, brk := NewWithBreaker(Config{
+		Threshold:      0.5,
+		MinRequests:    2,
+		WindowSize:     100 * time.Millisecond,
+		CooldownPeriod: 50 * time.Millisecond,
+		HalfOpenMax:    1,
+	})
+
+	tripBreaker(t, mw, 2)
+	time.Sleep(60 * time.Millisecond)
+
+	// First request in half-open: allowed (probe).
+	// We need a slow handler so we can test concurrent access.
+	slowHandler := func(c *celeris.Context) error {
+		time.Sleep(20 * time.Millisecond)
+		return c.String(200, "ok")
+	}
+
+	var wg sync.WaitGroup
+	var allowed, rejected atomic.Int32
+
+	for range 3 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			chain := []celeris.HandlerFunc{mw, slowHandler}
+			ctx, _ := celeristest.NewContext("GET", "/",
+				celeristest.WithHandlers(chain...))
+			err := ctx.Next()
+			celeristest.ReleaseContext(ctx)
+			if err != nil {
+				var he *celeris.HTTPError
+				if errors.As(err, &he) && he.Code == 503 {
+					rejected.Add(1)
+					return
+				}
+			}
+			allowed.Add(1)
+		}()
+	}
+
+	wg.Wait()
+	_ = brk
+
+	if allowed.Load() < 1 {
+		t.Fatal("expected at least 1 allowed request in half-open")
+	}
+	if rejected.Load() < 1 {
+		t.Fatal("expected at least 1 rejected request in half-open")
+	}
+}
+
+func TestMinRequestsPreventsPrematureTripping(t *testing.T) {
+	mw, brk := NewWithBreaker(Config{
+		Threshold:      0.5,
+		MinRequests:    10,
+		WindowSize:     1 * time.Second,
+		CooldownPeriod: 10 * time.Second,
+	})
+
+	// Send 5 failures (below MinRequests of 10).
+	failChain := []celeris.HandlerFunc{mw, errHandler500}
+	for range 5 {
+		_, _ = testutil.RunChain(t, failChain, "GET", "/")
+	}
+
+	if brk.State() != Closed {
+		t.Fatalf("expected Closed (below MinRequests), got %s", brk.State())
+	}
+}
+
+func TestCustomIsError(t *testing.T) {
+	mw, brk := NewWithBreaker(Config{
+		Threshold:      0.5,
+		MinRequests:    2,
+		WindowSize:     1 * time.Second,
+		CooldownPeriod: 10 * time.Second,
+		IsError: func(_ error, statusCode int) bool {
+			return statusCode == 429
+		},
+	})
+
+	// 500s should NOT count as errors with custom IsError.
+	failChain := []celeris.HandlerFunc{mw, errHandler500}
+	for range 5 {
+		_, _ = testutil.RunChain(t, failChain, "GET", "/")
+	}
+
+	if brk.State() != Closed {
+		t.Fatalf("expected Closed (500 not counted as error), got %s", brk.State())
+	}
+
+	// 429s should count. Need enough 429s to exceed threshold.
+	// After 5 successes (500 not counted as error) and 10 failures (429),
+	// ratio = 10/15 = 0.667 > 0.5.
+	handler429 := func(c *celeris.Context) error {
+		return celeris.NewHTTPError(429, "Too Many Requests")
+	}
+	chain429 := []celeris.HandlerFunc{mw, handler429}
+	for range 10 {
+		_, _ = testutil.RunChain(t, chain429, "GET", "/")
+	}
+
+	if brk.State() != Open {
+		t.Fatalf("expected Open (429 counted as error), got %s", brk.State())
+	}
+}
+
+func TestOnStateChangeCallback(t *testing.T) {
+	var mu sync.Mutex
+	var transitions [][2]State
+
+	mw, _ := NewWithBreaker(Config{
+		Threshold:      0.5,
+		MinRequests:    2,
+		WindowSize:     100 * time.Millisecond,
+		CooldownPeriod: 50 * time.Millisecond,
+		HalfOpenMax:    1,
+		OnStateChange: func(from, to State) {
+			mu.Lock()
+			transitions = append(transitions, [2]State{from, to})
+			mu.Unlock()
+		},
+	})
+
+	// Trip the breaker: Closed -> Open.
+	tripBreaker(t, mw, 2)
+
+	// Wait for cooldown, then send a successful request: Open -> HalfOpen -> Closed.
+	time.Sleep(60 * time.Millisecond)
+	chain := []celeris.HandlerFunc{mw, okHandler}
+	_, _ = testutil.RunChain(t, chain, "GET", "/")
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(transitions) < 3 {
+		t.Fatalf("expected at least 3 transitions, got %d: %v", len(transitions), transitions)
+	}
+
+	// Closed -> Open
+	if transitions[0] != [2]State{Closed, Open} {
+		t.Fatalf("transition[0]: got %v, want [Closed, Open]", transitions[0])
+	}
+	// Open -> HalfOpen
+	if transitions[1] != [2]State{Open, HalfOpen} {
+		t.Fatalf("transition[1]: got %v, want [Open, HalfOpen]", transitions[1])
+	}
+	// HalfOpen -> Closed
+	if transitions[2] != [2]State{HalfOpen, Closed} {
+		t.Fatalf("transition[2]: got %v, want [HalfOpen, Closed]", transitions[2])
+	}
+}
+
+func TestCustomErrorHandler(t *testing.T) {
+	customErr := celeris.NewHTTPError(503, "custom circuit open")
+	mw := New(Config{
+		Threshold:      0.5,
+		MinRequests:    2,
+		WindowSize:     1 * time.Second,
+		CooldownPeriod: 10 * time.Second,
+		ErrorHandler: func(c *celeris.Context, _ error) error {
+			return customErr
+		},
+	})
+
+	tripBreaker(t, mw, 2)
+
+	_, err := testutil.RunMiddleware(t, mw)
+	if err != customErr {
+		t.Fatalf("expected custom error, got %v", err)
+	}
+}
+
+func TestSkipPath(t *testing.T) {
+	mw, brk := NewWithBreaker(Config{
+		Threshold:      0.5,
+		MinRequests:    2,
+		WindowSize:     1 * time.Second,
+		CooldownPeriod: 10 * time.Second,
+		SkipPaths:      []string{"/health"},
+	})
+
+	// Trip the breaker.
+	tripBreaker(t, mw, 2)
+
+	if brk.State() != Open {
+		t.Fatalf("expected Open, got %s", brk.State())
+	}
+
+	// Skipped path should pass through even when open.
+	chain := []celeris.HandlerFunc{mw, okHandler}
+	rec, err := testutil.RunChain(t, chain, "GET", "/health")
+	testutil.AssertNoError(t, err)
+	testutil.AssertStatus(t, rec, 200)
+}
+
+func TestWindowExpiry(t *testing.T) {
+	mw, brk := NewWithBreaker(Config{
+		Threshold:      0.5,
+		MinRequests:    2,
+		WindowSize:     50 * time.Millisecond,
+		CooldownPeriod: 10 * time.Second,
+	})
+
+	// Send failures but within the window.
+	failChain := []celeris.HandlerFunc{mw, errHandler500}
+	_, _ = testutil.RunChain(t, failChain, "GET", "/")
+
+	// Wait for window to expire.
+	time.Sleep(70 * time.Millisecond)
+
+	// Send one more failure. Total in window is now 1 (below MinRequests=2).
+	_, _ = testutil.RunChain(t, failChain, "GET", "/")
+
+	if brk.State() != Closed {
+		t.Fatalf("expected Closed (old failures expired), got %s", brk.State())
+	}
+}
+
+func TestConcurrentSafety(t *testing.T) {
+	mw := New(Config{
+		Threshold:      0.5,
+		MinRequests:    2,
+		WindowSize:     100 * time.Millisecond,
+		CooldownPeriod: 50 * time.Millisecond,
+		HalfOpenMax:    1,
+	})
+
+	var wg sync.WaitGroup
+	for range 100 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			chain := []celeris.HandlerFunc{mw, func(c *celeris.Context) error {
+				if time.Now().UnixNano()%2 == 0 {
+					return celeris.NewHTTPError(500, "fail")
+				}
+				return c.String(200, "ok")
+			}}
+			ctx, _ := celeristest.NewContext("GET", "/",
+				celeristest.WithHandlers(chain...))
+			_ = ctx.Next()
+			celeristest.ReleaseContext(ctx)
+		}()
+	}
+	wg.Wait()
+}
+
+func TestResetMethod(t *testing.T) {
+	mw, brk := NewWithBreaker(Config{
+		Threshold:      0.5,
+		MinRequests:    2,
+		WindowSize:     1 * time.Second,
+		CooldownPeriod: 10 * time.Second,
+	})
+
+	tripBreaker(t, mw, 2)
+
+	if brk.State() != Open {
+		t.Fatalf("expected Open, got %s", brk.State())
+	}
+
+	brk.Reset()
+
+	if brk.State() != Closed {
+		t.Fatalf("expected Closed after Reset, got %s", brk.State())
+	}
+
+	// Should be able to pass requests again.
+	chain := []celeris.HandlerFunc{mw, okHandler}
+	rec, err := testutil.RunChain(t, chain, "GET", "/")
+	testutil.AssertNoError(t, err)
+	testutil.AssertStatus(t, rec, 200)
+}
+
+func TestDefaultConfigWorks(t *testing.T) {
+	mw := New()
+	chain := []celeris.HandlerFunc{mw, okHandler}
+	rec, err := testutil.RunChain(t, chain, "GET", "/")
+	testutil.AssertNoError(t, err)
+	testutil.AssertStatus(t, rec, 200)
+}
+
+func TestStateString(t *testing.T) {
+	tests := []struct {
+		state State
+		want  string
+	}{
+		{Closed, "closed"},
+		{Open, "open"},
+		{HalfOpen, "half-open"},
+		{State(99), "unknown"},
+	}
+	for _, tt := range tests {
+		if got := tt.state.String(); got != tt.want {
+			t.Errorf("State(%d).String() = %q, want %q", tt.state, got, tt.want)
+		}
+	}
+}
+
+func TestValidatePanics(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic for invalid Threshold")
+		}
+	}()
+	New(Config{Threshold: 1.5})
+}

--- a/middleware/circuitbreaker/config.go
+++ b/middleware/circuitbreaker/config.go
@@ -1,0 +1,122 @@
+package circuitbreaker
+
+import (
+	"time"
+
+	"github.com/goceleris/celeris"
+)
+
+// State represents the circuit breaker state.
+type State int
+
+const (
+	// Closed allows all requests through and monitors the error rate.
+	Closed State = iota
+	// Open rejects all requests immediately with 503.
+	Open
+	// HalfOpen allows a limited number of probe requests through.
+	HalfOpen
+)
+
+// String returns the human-readable state name.
+func (s State) String() string {
+	switch s {
+	case Closed:
+		return "closed"
+	case Open:
+		return "open"
+	case HalfOpen:
+		return "half-open"
+	default:
+		return "unknown"
+	}
+}
+
+// Config defines the circuit breaker middleware configuration.
+type Config struct {
+	// Skip defines a function to skip this middleware for certain requests.
+	Skip func(c *celeris.Context) bool
+
+	// SkipPaths lists paths to skip (exact match).
+	SkipPaths []string
+
+	// Threshold is the failure ratio (failures/total) that trips the breaker.
+	// Must be between 0 and 1 (exclusive). Default: 0.5.
+	Threshold float64
+
+	// MinRequests is the minimum number of requests in the current window
+	// before the breaker can trip. Prevents premature tripping on small
+	// sample sizes. Default: 10.
+	MinRequests int
+
+	// WindowSize is the duration of the sliding observation window.
+	// Default: 10s.
+	WindowSize time.Duration
+
+	// CooldownPeriod is how long the breaker stays open before transitioning
+	// to half-open. Default: 30s.
+	CooldownPeriod time.Duration
+
+	// HalfOpenMax is the maximum number of probe requests allowed through
+	// in the half-open state. Default: 1.
+	HalfOpenMax int
+
+	// IsError determines whether a response should be counted as a failure.
+	// Receives the error returned by the handler and the response status code.
+	// Default: status >= 500.
+	IsError func(err error, statusCode int) bool
+
+	// OnStateChange is called when the breaker transitions between states.
+	// Called under a mutex; keep the callback fast.
+	OnStateChange func(from, to State)
+
+	// ErrorHandler is called to produce a response when the breaker is open.
+	// Default: returns ErrServiceUnavailable (503).
+	ErrorHandler func(c *celeris.Context, err error) error
+}
+
+// ErrServiceUnavailable is returned when the circuit breaker is open.
+var ErrServiceUnavailable = celeris.NewHTTPError(503, "Service Unavailable")
+
+var defaultConfig = Config{
+	Threshold:      0.5,
+	MinRequests:    10,
+	WindowSize:     10 * time.Second,
+	CooldownPeriod: 30 * time.Second,
+	HalfOpenMax:    1,
+}
+
+func applyDefaults(cfg Config) Config {
+	if cfg.Threshold == 0 {
+		cfg.Threshold = defaultConfig.Threshold
+	}
+	if cfg.MinRequests == 0 {
+		cfg.MinRequests = defaultConfig.MinRequests
+	}
+	if cfg.WindowSize == 0 {
+		cfg.WindowSize = defaultConfig.WindowSize
+	}
+	if cfg.CooldownPeriod == 0 {
+		cfg.CooldownPeriod = defaultConfig.CooldownPeriod
+	}
+	if cfg.HalfOpenMax == 0 {
+		cfg.HalfOpenMax = defaultConfig.HalfOpenMax
+	}
+	if cfg.IsError == nil {
+		cfg.IsError = func(_ error, statusCode int) bool {
+			return statusCode >= 500
+		}
+	}
+	if cfg.ErrorHandler == nil {
+		cfg.ErrorHandler = func(_ *celeris.Context, _ error) error {
+			return ErrServiceUnavailable
+		}
+	}
+	return cfg
+}
+
+func validate(cfg Config) {
+	if cfg.Threshold <= 0 || cfg.Threshold > 1 {
+		panic("circuitbreaker: Threshold must be in (0, 1]")
+	}
+}

--- a/middleware/circuitbreaker/doc.go
+++ b/middleware/circuitbreaker/doc.go
@@ -66,7 +66,7 @@
 // use atomic operations (lock-free hot path). State transitions acquire a
 // mutex with double-check locking to prevent duplicate transitions.
 //
-// Basic usage with defaults (50% threshold, 10 min requests, 10s window):
+// Basic usage with defaults (50% threshold, minimum 10 requests, 10s window):
 //
 //	server.Use(circuitbreaker.New())
 //

--- a/middleware/circuitbreaker/doc.go
+++ b/middleware/circuitbreaker/doc.go
@@ -1,0 +1,95 @@
+// Package circuitbreaker provides circuit breaker middleware for celeris.
+//
+// The circuit breaker monitors downstream error rates using a sliding window
+// and automatically stops sending requests when failure thresholds are exceeded,
+// giving the failing service time to recover.
+//
+// # Three-State Machine
+//
+// The breaker operates in three states:
+//
+//   - Closed: All requests pass through. The sliding window tracks successes
+//     and failures. When the failure ratio meets or exceeds [Config].Threshold
+//     (and at least [Config].MinRequests have been observed), the breaker
+//     trips to Open.
+//
+//   - Open: All requests are immediately rejected with 503 Service Unavailable.
+//     A Retry-After header is set with the remaining cooldown seconds. After
+//     [Config].CooldownPeriod elapses, the breaker transitions to HalfOpen.
+//
+//   - HalfOpen: Up to [Config].HalfOpenMax probe requests are allowed through.
+//     If a probe succeeds, the breaker returns to Closed. If a probe fails,
+//     the breaker returns to Open. Excess requests beyond HalfOpenMax are
+//     rejected with 503.
+//
+// # Sliding Window Algorithm
+//
+// The observation window is divided into 10 time buckets spanning
+// [Config].WindowSize. Each bucket tracks successes and failures using atomic
+// counters. Expired buckets (older than WindowSize) are excluded from the
+// error rate calculation. This provides a smooth, time-decaying view of
+// the failure rate without requiring a global lock on the hot path.
+//
+// # Response Classification
+//
+// By default, responses with status >= 500 are counted as failures. Use
+// [Config].IsError to customize classification (e.g., treat 429 as a failure,
+// or ignore certain 5xx codes).
+//
+// # Retry-After Header
+//
+// When the breaker is open, the middleware sets a Retry-After header with
+// the number of seconds until the cooldown period expires. Clients that
+// respect this header avoid unnecessary retries during the cooldown.
+//
+// # Programmatic Access
+//
+// Use [NewWithBreaker] to obtain a reference to the underlying [Breaker]
+// struct. This allows programmatic state inspection ([Breaker.State]) and
+// forced reset ([Breaker.Reset]) for health checks, admin endpoints, or
+// integration tests.
+//
+// # Middleware Ordering
+//
+// Place the circuit breaker after rate limiting and before timeout middleware:
+//
+//	server.Use(ratelimit.New())
+//	server.Use(circuitbreaker.New())
+//	server.Use(timeout.New())
+//
+// This ensures rate-limited requests are rejected before reaching the breaker,
+// and timed-out requests are properly classified by the breaker.
+//
+// # Thread Safety
+//
+// The breaker is safe for concurrent use. State reads and counter updates
+// use atomic operations (lock-free hot path). State transitions acquire a
+// mutex with double-check locking to prevent duplicate transitions.
+//
+// Basic usage with defaults (50% threshold, 10 min requests, 10s window):
+//
+//	server.Use(circuitbreaker.New())
+//
+// Custom threshold and cooldown:
+//
+//	server.Use(circuitbreaker.New(circuitbreaker.Config{
+//	    Threshold:      0.3,
+//	    MinRequests:    20,
+//	    CooldownPeriod: time.Minute,
+//	}))
+//
+// Programmatic access for health checks:
+//
+//	mw, breaker := circuitbreaker.NewWithBreaker()
+//	server.Use(mw)
+//	server.GET("/health", func(c *celeris.Context) error {
+//	    if breaker.State() == circuitbreaker.Open {
+//	        return c.JSON(503, map[string]string{"circuit": "open"})
+//	    }
+//	    return c.JSON(200, map[string]string{"circuit": "closed"})
+//	})
+//
+// [ErrServiceUnavailable] is the exported sentinel error (503) returned when
+// the breaker is open, usable with errors.Is for error handling in upstream
+// middleware.
+package circuitbreaker

--- a/middleware/circuitbreaker/example_test.go
+++ b/middleware/circuitbreaker/example_test.go
@@ -1,0 +1,40 @@
+package circuitbreaker_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/goceleris/celeris/middleware/circuitbreaker"
+)
+
+func ExampleNew() {
+	// Zero-config: 50% threshold, 10 min requests, 10s window, 30s cooldown.
+	_ = circuitbreaker.New()
+}
+
+func ExampleNew_custom() {
+	// Custom threshold and cooldown period.
+	_ = circuitbreaker.New(circuitbreaker.Config{
+		Threshold:      0.3,
+		MinRequests:    20,
+		CooldownPeriod: time.Minute,
+	})
+}
+
+func ExampleNewWithBreaker() {
+	// Obtain a Breaker reference for programmatic state inspection.
+	mw, breaker := circuitbreaker.NewWithBreaker(circuitbreaker.Config{
+		Threshold:   0.5,
+		MinRequests: 10,
+		OnStateChange: func(from, to circuitbreaker.State) {
+			fmt.Printf("circuit breaker: %s -> %s\n", from, to)
+		},
+	})
+	_ = mw
+
+	// Use the breaker for health checks or admin endpoints.
+	fmt.Println(breaker.State())
+
+	// Output:
+	// closed
+}

--- a/middleware/circuitbreaker/window.go
+++ b/middleware/circuitbreaker/window.go
@@ -1,0 +1,76 @@
+package circuitbreaker
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+const numBuckets = 10
+
+type bucket struct {
+	successes atomic.Int64
+	failures  atomic.Int64
+	epoch     atomic.Int64 // start time of this bucket in nanoseconds
+}
+
+type slidingWindow struct {
+	buckets    [numBuckets]bucket
+	bucketSize int64 // nanoseconds per bucket
+	windowSize int64 // nanoseconds for the full window
+}
+
+func newSlidingWindow(windowSize time.Duration) *slidingWindow {
+	w := &slidingWindow{
+		bucketSize: int64(windowSize) / numBuckets,
+		windowSize: int64(windowSize),
+	}
+	return w
+}
+
+func (w *slidingWindow) currentBucket(now int64) *bucket {
+	idx := (now / w.bucketSize) % numBuckets
+	b := &w.buckets[idx]
+	epoch := (now / w.bucketSize) * w.bucketSize
+	if old := b.epoch.Load(); old != epoch {
+		if b.epoch.CompareAndSwap(old, epoch) {
+			b.successes.Store(0)
+			b.failures.Store(0)
+		}
+	}
+	return b
+}
+
+func (w *slidingWindow) recordSuccess() {
+	now := time.Now().UnixNano()
+	b := w.currentBucket(now)
+	b.successes.Add(1)
+}
+
+func (w *slidingWindow) recordFailure() {
+	now := time.Now().UnixNano()
+	b := w.currentBucket(now)
+	b.failures.Add(1)
+}
+
+func (w *slidingWindow) counts() (total, failures int64) {
+	now := time.Now().UnixNano()
+	cutoff := now - w.windowSize
+	for i := range numBuckets {
+		b := &w.buckets[i]
+		if b.epoch.Load() >= cutoff {
+			s := b.successes.Load()
+			f := b.failures.Load()
+			total += s + f
+			failures += f
+		}
+	}
+	return total, failures
+}
+
+func (w *slidingWindow) reset() {
+	for i := range numBuckets {
+		w.buckets[i].successes.Store(0)
+		w.buckets[i].failures.Store(0)
+		w.buckets[i].epoch.Store(0)
+	}
+}

--- a/middleware/doc.go
+++ b/middleware/doc.go
@@ -22,11 +22,13 @@
 //	cors        — handle preflight; must run before auth rejects OPTIONS
 //	bodylimit   — reject oversized bodies before parsing begins
 //	ratelimit   — shed load before expensive auth/business logic
+//	circuitbreaker — trip open on error rate spike; after ratelimit, before timeout
 //	[auth]      — jwt / keyauth / basicauth (see Auth Stacking below)
 //	csrf        — validate CSRF token after authentication is established
 //	session     — load session (may depend on authenticated user)
 //	debug       — intercepts by path prefix (e.g. /debug/); can go anywhere
 //	timeout     — bound handler execution; innermost wrapper before the route
+//	singleflight — collapse identical in-flight requests; after timeout
 //	compress    — response compression; wraps etag (computes on uncompressed body)
 //	etag        — conditional responses (304 Not Modified); innermost transform
 //	[handler]   — route handler
@@ -44,6 +46,9 @@
 //	s.Use(recovery.New())
 //	s.Use(cors.New())
 //	s.Use(secure.New())
+//	s.Use(circuitbreaker.New())
+//	s.Use(timeout.New(timeout.Config{Timeout: 30 * time.Second}))
+//	s.Use(singleflight.New())
 //	s.Use(compress.New())
 //	s.Use(etag.New())
 //

--- a/middleware/singleflight/bench_test.go
+++ b/middleware/singleflight/bench_test.go
@@ -1,0 +1,38 @@
+package singleflight
+
+import (
+	"testing"
+
+	"github.com/goceleris/celeris"
+	"github.com/goceleris/celeris/celeristest"
+)
+
+func BenchmarkSingleflightMiss(b *testing.B) {
+	mw := New()
+	handler := func(c *celeris.Context) error {
+		return c.Blob(200, "text/plain", []byte("hello"))
+	}
+	opts := []celeristest.Option{celeristest.WithHandlers(mw, handler)}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		ctx, _ := celeristest.NewContext("GET", "/bench", opts...)
+		_ = ctx.Next()
+		celeristest.ReleaseContext(ctx)
+	}
+}
+
+func BenchmarkSingleflightSkip(b *testing.B) {
+	mw := New(Config{SkipPaths: []string{"/skip"}})
+	handler := func(c *celeris.Context) error {
+		return c.Blob(200, "text/plain", []byte("hello"))
+	}
+	opts := []celeristest.Option{celeristest.WithHandlers(mw, handler)}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		ctx, _ := celeristest.NewContext("GET", "/skip", opts...)
+		_ = ctx.Next()
+		celeristest.ReleaseContext(ctx)
+	}
+}

--- a/middleware/singleflight/config.go
+++ b/middleware/singleflight/config.go
@@ -1,0 +1,41 @@
+package singleflight
+
+import "github.com/goceleris/celeris"
+
+// Config defines the singleflight middleware configuration.
+type Config struct {
+	// Skip defines a function to skip this middleware for certain requests.
+	Skip func(c *celeris.Context) bool
+
+	// SkipPaths lists paths to skip (exact match).
+	SkipPaths []string
+
+	// KeyFunc extracts the deduplication key from the request. Requests
+	// with the same key that arrive while a leader request is in-flight
+	// are coalesced — waiters receive a copy of the leader's response.
+	//
+	// Default: method + "\x00" + path + "\x00" + sorted-query-string.
+	KeyFunc func(c *celeris.Context) string
+}
+
+var defaultConfig = Config{}
+
+func applyDefaults(cfg Config) Config {
+	if cfg.KeyFunc == nil {
+		cfg.KeyFunc = defaultKeyFunc
+	}
+	return cfg
+}
+
+func validate(Config) {}
+
+func defaultKeyFunc(c *celeris.Context) string {
+	m := c.Method()
+	p := c.Path()
+	rq := c.RawQuery()
+	if rq == "" {
+		return m + "\x00" + p
+	}
+	sorted := c.QueryParams().Encode()
+	return m + "\x00" + p + "\x00" + sorted
+}

--- a/middleware/singleflight/doc.go
+++ b/middleware/singleflight/doc.go
@@ -1,0 +1,99 @@
+// Package singleflight provides request deduplication middleware for celeris.
+//
+// When multiple identical requests arrive concurrently, only the first
+// (the "leader") executes the handler chain. Subsequent requests (the
+// "waiters") block until the leader completes, then receive a copy of
+// the leader's response. This prevents the thundering herd problem where
+// a popular endpoint receives a burst of identical requests that all hit
+// the backend simultaneously.
+//
+// Basic usage:
+//
+//	server.Use(singleflight.New())
+//
+// Custom key function:
+//
+//	server.Use(singleflight.New(singleflight.Config{
+//	    KeyFunc: func(c *celeris.Context) string {
+//	        return c.Path() // ignore query parameters
+//	    },
+//	}))
+//
+// # Algorithm
+//
+// The middleware maintains an in-memory map of in-flight keys. For each
+// incoming request:
+//
+//  1. Compute the deduplication key via [Config].KeyFunc.
+//  2. Lock the group and check the map.
+//  3. If the key exists, the request is a waiter: unlock, wait for the
+//     leader to finish, then replay the captured response.
+//  4. If the key is absent, the request is the leader: register the key,
+//     unlock, buffer the response, execute c.Next(), capture the result,
+//     remove the key from the map, and wake all waiters.
+//
+// The embedded singleflight group uses no external dependencies.
+//
+// # Default Key
+//
+// The default key function produces: method + "\x00" + path + "\x00" +
+// sorted query string. Query parameters are sorted via [url.Values.Encode]
+// so that ?a=1&b=2 and ?b=2&a=1 produce the same key. When the request
+// has no query string, the query component is omitted entirely (no
+// parsing overhead).
+//
+// # x-singleflight Response Header
+//
+// Waiter responses include the header "x-singleflight: HIT" so that
+// callers (and observability tools) can distinguish coalesced responses
+// from leader responses. The leader response does not carry this header.
+//
+// # Middleware Ordering
+//
+// Singleflight should run AFTER timeout middleware (so each coalesced
+// request respects its own timeout) and BEFORE transform middleware
+// like compress or etag (so the response is captured before transformation):
+//
+//	server.Use(timeout.New(...))      // outermost
+//	server.Use(singleflight.New())    // dedup on uncompressed response
+//	server.Use(compress.New())        // innermost
+//	server.Use(etag.New())
+//
+// # Idempotency
+//
+// Singleflight is designed for idempotent read endpoints (GET, HEAD).
+// Using it on non-idempotent methods (POST, PUT, DELETE) may cause
+// unintended behavior: only one request executes and all waiters receive
+// the same response. If your endpoint modifies state, either skip it
+// with [Config].SkipPaths or use a [Config].KeyFunc that differentiates
+// by request body or session.
+//
+// # Error Propagation
+//
+// If the leader's handler returns an error, all waiters receive the same
+// error. The error is propagated as-is (including [celeris.HTTPError]
+// with its status code).
+//
+// # Panic Propagation
+//
+// If the leader's handler panics, the panic value is captured and
+// re-panicked in every waiter goroutine (and in the leader after
+// cleanup). This ensures recovery middleware further up the chain
+// catches the panic in every request context.
+//
+// # Non-2xx Responses
+//
+// Non-2xx responses (404, 500, etc.) are coalesced just like 2xx
+// responses. The middleware does not distinguish between success and
+// failure status codes — it deduplicates all in-flight requests for
+// the same key.
+//
+// # Skipping
+//
+// Use [Config].Skip for dynamic skip logic or [Config].SkipPaths for
+// path exclusions. SkipPaths uses exact path matching:
+//
+//	server.Use(singleflight.New(singleflight.Config{
+//	    SkipPaths: []string{"/admin", "/webhook"},
+//	}))
+package singleflight

--- a/middleware/singleflight/example_test.go
+++ b/middleware/singleflight/example_test.go
@@ -1,0 +1,23 @@
+package singleflight_test
+
+import (
+	"github.com/goceleris/celeris"
+	"github.com/goceleris/celeris/middleware/singleflight"
+)
+
+func ExampleNew() {
+	// Deduplicate concurrent identical GET requests using the default key
+	// (method + path + sorted query string).
+	// s := celeris.New()
+	// s.Use(singleflight.New())
+	_ = singleflight.New()
+}
+
+func ExampleNew_customKey() {
+	// Use only the path as the deduplication key, ignoring query parameters.
+	_ = singleflight.New(singleflight.Config{
+		KeyFunc: func(c *celeris.Context) string {
+			return c.Method() + "\x00" + c.Path()
+		},
+	})
+}

--- a/middleware/singleflight/singleflight.go
+++ b/middleware/singleflight/singleflight.go
@@ -1,0 +1,114 @@
+package singleflight
+
+import (
+	"sync"
+
+	"github.com/goceleris/celeris"
+)
+
+type call struct {
+	wg       sync.WaitGroup
+	status   int
+	headers  [][2]string
+	body     []byte
+	ct       string
+	err      error
+	panicVal any
+}
+
+type group struct {
+	mu sync.Mutex
+	m  map[string]*call
+}
+
+// New creates a singleflight middleware with the given config.
+func New(config ...Config) celeris.HandlerFunc {
+	cfg := defaultConfig
+	if len(config) > 0 {
+		cfg = config[0]
+	}
+	cfg = applyDefaults(cfg)
+	validate(cfg)
+
+	var skip celeris.SkipHelper
+	skip.Init(cfg.SkipPaths, cfg.Skip)
+
+	keyFunc := cfg.KeyFunc
+
+	g := &group{m: make(map[string]*call)}
+
+	return func(c *celeris.Context) error {
+		if skip.ShouldSkip(c) {
+			return c.Next()
+		}
+
+		key := keyFunc(c)
+
+		g.mu.Lock()
+		if entry, ok := g.m[key]; ok {
+			// Waiter path: another request is already in-flight for this key.
+			g.mu.Unlock()
+			entry.wg.Wait()
+
+			if entry.panicVal != nil {
+				panic(entry.panicVal)
+			}
+
+			c.Abort()
+			c.SetHeader("x-singleflight", "HIT")
+			for _, h := range entry.headers {
+				c.SetHeader(h[0], h[1])
+			}
+			if entry.ct == "" {
+				_ = c.NoContent(entry.status)
+			} else {
+				_ = c.Blob(entry.status, entry.ct, entry.body)
+			}
+			return entry.err
+		}
+
+		// Leader path: first request for this key.
+		entry := &call{}
+		entry.wg.Add(1)
+		g.m[key] = entry
+		g.mu.Unlock()
+
+		c.BufferResponse()
+
+		var panicVal any
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					panicVal = r
+				}
+			}()
+			entry.err = c.Next()
+		}()
+
+		// Capture response state (deep copy).
+		entry.status = c.ResponseStatus()
+		entry.ct = c.ResponseContentType()
+		body := c.ResponseBody()
+		if len(body) > 0 {
+			entry.body = append([]byte(nil), body...)
+		}
+		respHeaders := c.ResponseHeaders()
+		if len(respHeaders) > 0 {
+			entry.headers = make([][2]string, len(respHeaders))
+			copy(entry.headers, respHeaders)
+		}
+		entry.panicVal = panicVal
+
+		// Remove from map BEFORE wg.Done so new requests after Done create fresh entries.
+		g.mu.Lock()
+		delete(g.m, key)
+		entry.wg.Done()
+		g.mu.Unlock()
+
+		if panicVal != nil {
+			panic(panicVal)
+		}
+
+		return c.FlushResponse()
+	}
+}

--- a/middleware/singleflight/singleflight_test.go
+++ b/middleware/singleflight/singleflight_test.go
@@ -1,0 +1,506 @@
+package singleflight
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/goceleris/celeris"
+	"github.com/goceleris/celeris/celeristest"
+	"github.com/goceleris/celeris/middleware/internal/testutil"
+)
+
+// concurrentTest runs a leader + N-1 waiter pattern deterministically.
+//
+// Synchronization protocol uses a two-phase key function:
+//  1. Leader's KeyFunc call passes through immediately. Leader enters
+//     handler and blocks on gate.
+//  2. Each waiter's KeyFunc call signals (waiterArrived) from inside
+//     the middleware, then blocks on waiterGate.
+//  3. The test waits for all N-1 waiterArrived signals, then closes
+//     waiterGate to release waiters. Waiters proceed to the group lock
+//     and map check. Since the leader is still blocked in the handler,
+//     the key is in the map and waiters take the waiter path (wg.Wait).
+//  4. After a brief yield to let waiters reach wg.Wait (only a lock
+//     acquire + map lookup separates KeyFunc from wg.Wait), the test
+//     closes gate to release the leader.
+type concurrentTest struct {
+	handler celeris.HandlerFunc
+	n       int
+	method  string
+	path    string
+	key     string
+
+	entered       chan struct{}
+	gate          chan struct{}
+	enterOnce     sync.Once
+	wg            sync.WaitGroup
+	waiterArrived sync.WaitGroup
+	waiterGate    chan struct{}
+	recs          []*celeristest.ResponseRecorder
+	errs          []error
+	panics        []any
+	ctxs          []*celeris.Context
+}
+
+func (ct *concurrentTest) init() {
+	if ct.key == "" {
+		ct.key = ct.method + "\x00" + ct.path
+	}
+	if ct.waiterGate == nil {
+		ct.waiterGate = make(chan struct{})
+	}
+	ct.recs = make([]*celeristest.ResponseRecorder, ct.n)
+	ct.errs = make([]error, ct.n)
+	ct.ctxs = make([]*celeris.Context, ct.n)
+	ct.wg.Add(ct.n)
+	ct.waiterArrived.Add(ct.n - 1)
+}
+
+func (ct *concurrentTest) cleanup(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		for _, ctx := range ct.ctxs {
+			if ctx != nil {
+				celeristest.ReleaseContext(ctx)
+			}
+		}
+	})
+}
+
+func (ct *concurrentTest) makeMW() celeris.HandlerFunc {
+	var leaderOnce sync.Once
+	return New(Config{
+		KeyFunc: func(c *celeris.Context) string {
+			isLeader := false
+			leaderOnce.Do(func() { isLeader = true })
+			if !isLeader {
+				ct.waiterArrived.Done()
+				<-ct.waiterGate
+			}
+			return ct.key
+		},
+	})
+}
+
+func (ct *concurrentTest) run(t *testing.T) {
+	t.Helper()
+	ct.init()
+	mw := ct.makeMW()
+
+	go func() {
+		defer ct.wg.Done()
+		chain := []celeris.HandlerFunc{mw, ct.handler}
+		opts := []celeristest.Option{celeristest.WithHandlers(chain...)}
+		ctx, rec := celeristest.NewContext(ct.method, ct.path, opts...)
+		ct.ctxs[0] = ctx
+		ct.recs[0] = rec
+		ct.errs[0] = ctx.Next()
+	}()
+
+	<-ct.entered
+
+	for i := 1; i < ct.n; i++ {
+		go func(idx int) {
+			defer ct.wg.Done()
+			chain := []celeris.HandlerFunc{mw, ct.handler}
+			opts := []celeristest.Option{celeristest.WithHandlers(chain...)}
+			ctx, rec := celeristest.NewContext(ct.method, ct.path, opts...)
+			ct.ctxs[idx] = ctx
+			ct.recs[idx] = rec
+			ct.errs[idx] = ctx.Next()
+		}(i)
+	}
+
+	// All waiters are blocked inside KeyFunc inside the middleware.
+	ct.waiterArrived.Wait()
+	// Release waiters. They proceed to the group lock + map check.
+	// The leader is still blocked in the handler, so the key is in the map.
+	close(ct.waiterGate)
+	// Brief yield: waiters need only a lock acquire + map lookup to reach
+	// wg.Wait(). 1ms is orders of magnitude more than needed.
+	time.Sleep(time.Millisecond)
+	// Release the leader handler.
+	close(ct.gate)
+	ct.wg.Wait()
+	ct.cleanup(t)
+}
+
+func (ct *concurrentTest) runWithPanics(t *testing.T) {
+	t.Helper()
+	ct.init()
+	ct.panics = make([]any, ct.n)
+	mw := ct.makeMW()
+
+	go func() {
+		defer ct.wg.Done()
+		defer func() { ct.panics[0] = recover() }()
+		chain := []celeris.HandlerFunc{mw, ct.handler}
+		opts := []celeristest.Option{celeristest.WithHandlers(chain...)}
+		ctx, rec := celeristest.NewContext(ct.method, ct.path, opts...)
+		ct.ctxs[0] = ctx
+		ct.recs[0] = rec
+		ct.errs[0] = ctx.Next()
+	}()
+
+	<-ct.entered
+
+	for i := 1; i < ct.n; i++ {
+		go func(idx int) {
+			defer ct.wg.Done()
+			defer func() { ct.panics[idx] = recover() }()
+			chain := []celeris.HandlerFunc{mw, ct.handler}
+			opts := []celeristest.Option{celeristest.WithHandlers(chain...)}
+			ctx, rec := celeristest.NewContext(ct.method, ct.path, opts...)
+			ct.ctxs[idx] = ctx
+			ct.recs[idx] = rec
+			ct.errs[idx] = ctx.Next()
+		}(i)
+	}
+
+	ct.waiterArrived.Wait()
+	close(ct.waiterGate)
+	time.Sleep(time.Millisecond)
+	close(ct.gate)
+	ct.wg.Wait()
+	ct.cleanup(t)
+}
+
+func TestSingleRequestPassthrough(t *testing.T) {
+	var called atomic.Int32
+	handler := func(c *celeris.Context) error {
+		called.Add(1)
+		return c.Blob(200, "text/plain", []byte("ok"))
+	}
+	mw := New()
+	rec, err := testutil.RunChain(t, []celeris.HandlerFunc{mw, handler}, "GET", "/test")
+	testutil.AssertNoError(t, err)
+	testutil.AssertStatus(t, rec, 200)
+	testutil.AssertBodyContains(t, rec, "ok")
+	if called.Load() != 1 {
+		t.Fatalf("handler called %d times, want 1", called.Load())
+	}
+}
+
+func TestConcurrentIdenticalRequestsCoalesced(t *testing.T) {
+	var callCount atomic.Int32
+	ct := &concurrentTest{
+		n:       10,
+		method:  "GET",
+		path:    "/same",
+		entered: make(chan struct{}),
+		gate:    make(chan struct{}),
+	}
+	ct.handler = func(c *celeris.Context) error {
+		callCount.Add(1)
+		ct.enterOnce.Do(func() { close(ct.entered) })
+		<-ct.gate
+		return c.Blob(200, "text/plain", []byte("coalesced"))
+	}
+	ct.run(t)
+
+	if callCount.Load() != 1 {
+		t.Fatalf("handler called %d times, want 1", callCount.Load())
+	}
+	for i := range ct.n {
+		if ct.errs[i] != nil {
+			t.Fatalf("goroutine %d: unexpected error: %v", i, ct.errs[i])
+		}
+		if string(ct.recs[i].Body) != "coalesced" {
+			t.Fatalf("goroutine %d: body = %q, want %q", i, ct.recs[i].Body, "coalesced")
+		}
+	}
+}
+
+func TestDifferentKeysNotCoalesced(t *testing.T) {
+	var callCount atomic.Int32
+	handler := func(c *celeris.Context) error {
+		callCount.Add(1)
+		return c.Blob(200, "text/plain", []byte("ok"))
+	}
+	mw := New()
+
+	rec1, err1 := testutil.RunChain(t, []celeris.HandlerFunc{mw, handler}, "GET", "/a")
+	testutil.AssertNoError(t, err1)
+	testutil.AssertStatus(t, rec1, 200)
+
+	rec2, err2 := testutil.RunChain(t, []celeris.HandlerFunc{mw, handler}, "GET", "/b")
+	testutil.AssertNoError(t, err2)
+	testutil.AssertStatus(t, rec2, 200)
+
+	if callCount.Load() != 2 {
+		t.Fatalf("handler called %d times, want 2", callCount.Load())
+	}
+}
+
+func TestErrorPropagationToWaiters(t *testing.T) {
+	testErr := errors.New("handler failed")
+	ct := &concurrentTest{
+		n:       5,
+		method:  "GET",
+		path:    "/err",
+		entered: make(chan struct{}),
+		gate:    make(chan struct{}),
+	}
+	ct.handler = func(c *celeris.Context) error {
+		ct.enterOnce.Do(func() { close(ct.entered) })
+		<-ct.gate
+		return testErr
+	}
+	ct.run(t)
+
+	for i := 1; i < ct.n; i++ {
+		if !errors.Is(ct.errs[i], testErr) {
+			t.Fatalf("goroutine %d: err = %v, want %v", i, ct.errs[i], testErr)
+		}
+	}
+}
+
+func TestPanicPropagationToWaiters(t *testing.T) {
+	ct := &concurrentTest{
+		n:       5,
+		method:  "GET",
+		path:    "/panic",
+		entered: make(chan struct{}),
+		gate:    make(chan struct{}),
+	}
+	ct.handler = func(c *celeris.Context) error {
+		ct.enterOnce.Do(func() { close(ct.entered) })
+		<-ct.gate
+		panic("boom")
+	}
+	ct.runWithPanics(t)
+
+	for i := range ct.n {
+		if ct.panics[i] != "boom" {
+			t.Fatalf("goroutine %d: panic = %v, want %q", i, ct.panics[i], "boom")
+		}
+	}
+}
+
+func TestSkipPath(t *testing.T) {
+	handler := func(c *celeris.Context) error {
+		return c.Blob(200, "text/plain", []byte("ok"))
+	}
+	mw := New(Config{SkipPaths: []string{"/health"}})
+
+	rec, err := testutil.RunChain(t, []celeris.HandlerFunc{mw, handler}, "GET", "/health")
+	testutil.AssertNoError(t, err)
+	testutil.AssertStatus(t, rec, 200)
+	testutil.AssertNoHeader(t, rec, "x-singleflight")
+}
+
+func TestSkipFunction(t *testing.T) {
+	handler := func(c *celeris.Context) error {
+		return c.Blob(200, "text/plain", []byte("ok"))
+	}
+	mw := New(Config{
+		Skip: func(c *celeris.Context) bool {
+			return c.Method() == "POST"
+		},
+	})
+
+	rec, err := testutil.RunChain(t, []celeris.HandlerFunc{mw, handler}, "POST", "/data")
+	testutil.AssertNoError(t, err)
+	testutil.AssertStatus(t, rec, 200)
+	testutil.AssertNoHeader(t, rec, "x-singleflight")
+}
+
+func TestCustomKeyFunc(t *testing.T) {
+	var callCount atomic.Int32
+	ct := &concurrentTest{
+		n:       2,
+		method:  "GET",
+		path:    "/a",
+		key:     "fixed-key",
+		entered: make(chan struct{}),
+		gate:    make(chan struct{}),
+	}
+	ct.handler = func(c *celeris.Context) error {
+		callCount.Add(1)
+		ct.enterOnce.Do(func() { close(ct.entered) })
+		<-ct.gate
+		return c.Blob(200, "text/plain", []byte("custom"))
+	}
+	ct.run(t)
+
+	if callCount.Load() != 1 {
+		t.Fatalf("handler called %d times, want 1", callCount.Load())
+	}
+}
+
+func TestDefaultKeySamePathQuery(t *testing.T) {
+	fn := defaultKeyFunc
+
+	ctx1, _ := celeristest.NewContext("GET", "/path?a=1&b=2")
+	defer celeristest.ReleaseContext(ctx1)
+	ctx2, _ := celeristest.NewContext("GET", "/path?a=1&b=2")
+	defer celeristest.ReleaseContext(ctx2)
+
+	k1 := fn(ctx1)
+	k2 := fn(ctx2)
+	if k1 != k2 {
+		t.Fatalf("same path+query: keys differ: %q vs %q", k1, k2)
+	}
+}
+
+func TestDefaultKeyDifferentQuery(t *testing.T) {
+	fn := defaultKeyFunc
+
+	ctx1, _ := celeristest.NewContext("GET", "/path?a=1")
+	defer celeristest.ReleaseContext(ctx1)
+	ctx2, _ := celeristest.NewContext("GET", "/path?a=2")
+	defer celeristest.ReleaseContext(ctx2)
+
+	k1 := fn(ctx1)
+	k2 := fn(ctx2)
+	if k1 == k2 {
+		t.Fatalf("different query: keys should differ: %q vs %q", k1, k2)
+	}
+}
+
+func TestDefaultKeySameParamsDifferentOrder(t *testing.T) {
+	fn := defaultKeyFunc
+
+	ctx1, _ := celeristest.NewContext("GET", "/path?b=2&a=1")
+	defer celeristest.ReleaseContext(ctx1)
+	ctx2, _ := celeristest.NewContext("GET", "/path?a=1&b=2")
+	defer celeristest.ReleaseContext(ctx2)
+
+	k1 := fn(ctx1)
+	k2 := fn(ctx2)
+	if k1 != k2 {
+		t.Fatalf("same params different order: keys differ: %q vs %q", k1, k2)
+	}
+}
+
+func TestResponseHeadersPreservedForWaiters(t *testing.T) {
+	ct := &concurrentTest{
+		n:       2,
+		method:  "GET",
+		path:    "/headers",
+		entered: make(chan struct{}),
+		gate:    make(chan struct{}),
+	}
+	ct.handler = func(c *celeris.Context) error {
+		c.SetHeader("x-custom", "value123")
+		ct.enterOnce.Do(func() { close(ct.entered) })
+		<-ct.gate
+		return c.Blob(200, "text/plain", []byte("headers"))
+	}
+	ct.run(t)
+
+	if ct.recs[1].Header("x-singleflight") != "HIT" {
+		t.Fatal("waiter missing x-singleflight: HIT header")
+	}
+	if ct.recs[1].Header("x-custom") != "value123" {
+		t.Fatalf("waiter x-custom = %q, want %q", ct.recs[1].Header("x-custom"), "value123")
+	}
+}
+
+func TestResponseBodyPreservedForWaiters(t *testing.T) {
+	body := "response-body-preserved"
+	ct := &concurrentTest{
+		n:       3,
+		method:  "GET",
+		path:    "/body",
+		entered: make(chan struct{}),
+		gate:    make(chan struct{}),
+	}
+	ct.handler = func(c *celeris.Context) error {
+		ct.enterOnce.Do(func() { close(ct.entered) })
+		<-ct.gate
+		return c.Blob(200, "application/json", []byte(body))
+	}
+	ct.run(t)
+
+	for i := range ct.n {
+		if string(ct.recs[i].Body) != body {
+			t.Fatalf("goroutine %d: body = %q, want %q", i, ct.recs[i].Body, body)
+		}
+	}
+}
+
+func TestNon2xxResponsesCoalesced(t *testing.T) {
+	ct := &concurrentTest{
+		n:       3,
+		method:  "GET",
+		path:    "/missing",
+		entered: make(chan struct{}),
+		gate:    make(chan struct{}),
+	}
+	ct.handler = func(c *celeris.Context) error {
+		ct.enterOnce.Do(func() { close(ct.entered) })
+		<-ct.gate
+		return c.Blob(404, "text/plain", []byte("not found"))
+	}
+	ct.run(t)
+
+	for i := range ct.n {
+		if ct.recs[i].StatusCode != 404 {
+			t.Fatalf("goroutine %d: status = %d, want 404", i, ct.recs[i].StatusCode)
+		}
+	}
+}
+
+func TestSingleflightHITHeaderOnWaiters(t *testing.T) {
+	ct := &concurrentTest{
+		n:       3,
+		method:  "GET",
+		path:    "/hit",
+		entered: make(chan struct{}),
+		gate:    make(chan struct{}),
+	}
+	ct.handler = func(c *celeris.Context) error {
+		ct.enterOnce.Do(func() { close(ct.entered) })
+		<-ct.gate
+		return c.Blob(200, "text/plain", []byte("ok"))
+	}
+	ct.run(t)
+
+	hitCount := 0
+	for i := range ct.n {
+		if ct.recs[i].Header("x-singleflight") == "HIT" {
+			hitCount++
+		}
+	}
+	if hitCount != 2 {
+		t.Fatalf("expected 2 HIT headers, got %d", hitCount)
+	}
+	if ct.recs[0].Header("x-singleflight") == "HIT" {
+		t.Fatal("leader should not have x-singleflight: HIT header")
+	}
+}
+
+func TestConcurrentSafety(t *testing.T) {
+	handler := func(c *celeris.Context) error {
+		return c.Blob(200, "text/plain", []byte("ok"))
+	}
+	mw := New()
+
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n)
+	ready := make(chan struct{})
+
+	for i := range n {
+		go func(idx int) {
+			defer wg.Done()
+			chain := []celeris.HandlerFunc{mw, handler}
+			path := "/race-a"
+			if idx%2 == 1 {
+				path = "/race-b"
+			}
+			opts := []celeristest.Option{celeristest.WithHandlers(chain...)}
+			ctx, _ := celeristest.NewContext("GET", path, opts...)
+			defer celeristest.ReleaseContext(ctx)
+			<-ready
+			_ = ctx.Next()
+		}(i)
+	}
+
+	close(ready)
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

Two new resilience middleware for v1.3.2:

| Package | Description | Tests | Benchmarks |
|---|---|---|---|
| **singleflight** | Request coalescing — collapse N identical in-flight requests into 1 handler call | 16 | 2 |
| **circuitbreaker** | 3-state circuit breaker with sliding window error rate, 503 + Retry-After | 20 | 3 |

### Singleflight
- Embedded group implementation (no external deps)
- Default key: method + path + sorted query (deterministic)
- `x-singleflight: HIT` header on coalesced responses
- Panic/error propagation from leader to waiters
- Deep-copy response for safe fan-out

### Circuit Breaker
- Lock-free sliding window (10 atomic time buckets)
- Atomic state reads on hot path, mutex only on transitions
- `NewWithBreaker()` for programmatic `State()`/`Reset()`
- Configurable: threshold, window, cooldown, IsError, OnStateChange

### Chain Benchmarks
| Chain | ns/op | allocs |
|---|---|---|
| With CircuitBreaker (reqid+recovery+cb+timeout) | 1272 | 19 |
| With Singleflight (reqid+recovery+sf+etag) | 628 | 10 |

## Test plan
- [x] `go test -race -count=1` both packages (36 tests)
- [x] `go test -bench=BenchmarkChain` chain benchmarks (18 chains)
- [x] `go vet ./middleware/...` clean
- [x] `go build ./...` clean

Closes #200, Closes #187