### PR TITLE
fix: post-merge CI flakes + iouring detached close race

### DIFF
--- a/engine/iouring/worker.go
+++ b/engine/iouring/worker.go
@@ -983,7 +983,7 @@ func (w *Worker) handleSend(c *completionEntry, fd int, now int64) {
 			mu.Unlock()
 		}
 		if cs.closing {
-			w.finishClose(fd)
+			w.finishCloseAny(fd, cs)
 		} else {
 			w.closeConn(fd)
 		}
@@ -1020,7 +1020,7 @@ func (w *Worker) completeSend(cs *connState, fd int, sent int, now int64) {
 			cs.h1State.OnError(errIORingSend(int32(sent)))
 		}
 		if cs.closing {
-			w.finishClose(fd)
+			w.finishCloseAny(fd, cs)
 		} else {
 			w.closeConn(fd)
 		}
@@ -1038,7 +1038,7 @@ func (w *Worker) completeSend(cs *connState, fd int, sent int, now int64) {
 	// detachMu (if any) is held by the deferred unlock at the top of
 	// the function — no per-branch Unlock needed below.
 	if cs.closing && len(cs.sendBuf) == 0 && len(cs.writeBuf) == 0 {
-		w.finishClose(fd)
+		w.finishCloseAny(fd, cs)
 		return
 	}
 
@@ -1109,21 +1109,28 @@ func (w *Worker) closeConn(fd int) {
 		w.removeH2Conn(fd)
 	}
 
-	if detached {
-		// Skip deferred-close and pool return for detached connections.
-		// The goroutine's closures still reference cs; GC collects it
-		// after the goroutine finishes.
-		w.finishCloseDetached(fd, cs)
-		return
-	}
-
 	// Defer actual close until all in-flight and pending SENDs complete,
-	// so GOAWAY / RST_STREAM data reaches the client.
+	// so the last bytes (GOAWAY / RST_STREAM / WS close-echo) reach the
+	// client before SHUT_WR. For detached connections this specifically
+	// guards the WS close handshake: the WS middleware queues a close-
+	// echo frame and then asks the engine to drop the FD via
+	// SetWSIdleDeadline(1); without this guard the subsequent
+	// checkTimeouts → closeConn pair would fire before the SEND SQE
+	// submitted by the dirty-list flush has completed, and the echo
+	// would never leave the kernel.
 	if cs.sending || cs.zcNotifPending || len(cs.sendBuf) > 0 || len(cs.writeBuf) > 0 {
 		cs.closing = true
 		if w.flushSend(cs) {
 			w.markDirty(cs)
 		}
+		return
+	}
+
+	if detached {
+		// Skip deferred-close and pool return for detached connections.
+		// The goroutine's closures still reference cs; GC collects it
+		// after the goroutine finishes.
+		w.finishCloseDetached(fd, cs)
 		return
 	}
 
@@ -1173,6 +1180,18 @@ func (w *Worker) finishClose(fd int) {
 		prepClose(sqe, fd)
 		setSQEUserData(sqe, encodeUserData(udClose, fd))
 	}
+}
+
+// finishCloseAny dispatches to finishCloseDetached for detached connections
+// and finishClose otherwise. Used by the deferred-close paths in
+// handleSend / completeSend, where the connection may be either a plain
+// H1/H2 conn or a detached WS/SSE conn (distinguished by detachMu).
+func (w *Worker) finishCloseAny(fd int, cs *connState) {
+	if cs.detachMu != nil {
+		w.finishCloseDetached(fd, cs)
+		return
+	}
+	w.finishClose(fd)
 }
 
 // finishCloseDetached closes the FD and removes the connection from bookkeeping

--- a/middleware/websocket/websocket_test.go
+++ b/middleware/websocket/websocket_test.go
@@ -1721,9 +1721,15 @@ func TestWriteBufferPool(t *testing.T) {
 		getCalls: &getCalls,
 		putCalls: &putCalls,
 	}
+	// handlerDone signals the test that WriteMessage's defer chain
+	// (including putWriter) has fully completed, so the pool counter
+	// check doesn't race the handler's post-Flush defers on slow CI
+	// VMs. Same shape as TestWriteBufferPoolHijackOnly (efebbba).
+	handlerDone := make(chan struct{})
 	addr, shutdown := startServer(t, Config{
 		WriteBufferPool: pool,
 		Handler: func(c *Conn) {
+			defer close(handlerDone)
 			mt, msg, err := c.ReadMessage()
 			if err != nil {
 				return
@@ -1739,6 +1745,11 @@ func TestWriteBufferPool(t *testing.T) {
 	_, _, data := client.readServerFrame(t)
 	if string(data) != "pool test" {
 		t.Errorf("got %q", data)
+	}
+	select {
+	case <-handlerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not complete within 2s")
 	}
 	if getCalls.Load() == 0 {
 		t.Error("pool.Get was never called")

--- a/test/integration/adaptive_hybrid_test.go
+++ b/test/integration/adaptive_hybrid_test.go
@@ -341,10 +341,25 @@ func TestAdaptiveConstrainedRing(t *testing.T) {
 	startEngine(t, e)
 
 	addr := e.Addr().String()
-	client := &http.Client{Timeout: 3 * time.Second}
-	resp, err := client.Get("http://" + addr + "/constrained")
-	if err != nil {
-		t.Fatalf("request failed: %v", err)
+	// On Azure CI VMs the adaptive engine may transiently reset
+	// connections during io_uring stabilization (ACCEPT_DIRECT EINVAL),
+	// so retry with backoff — same pattern as TestAdaptiveAutoSingleWorker
+	// (commits 88c92b2 / f912fd4).
+	client := &http.Client{
+		Timeout:   3 * time.Second,
+		Transport: &http.Transport{DisableKeepAlives: true},
+	}
+	var resp *http.Response
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		resp, err = client.Get("http://" + addr + "/constrained")
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("request failed after retries: %v", err)
+		}
+		time.Sleep(100 * time.Millisecond)
 	}
 	_ = resp.Body.Close()
 	if resp.StatusCode != 200 {


### PR DESCRIPTION
## Summary

Post-merge CI hit three independent failures once the v1.3.4 changes
landed on GitHub Actions runners. All three are pre-existing latent
bugs surfaced by the new test matrix (kernel 6.17 = iouring tier=optional,
taskset-pinned CPUs):

1. **`TestWriteBufferPool`** (Test job) — pool counter race. The test
   checked `putCalls` immediately after `readServerFrame`, but the
   server's `WriteMessage` defer chain (`unlockWrite → putWriter`) runs
   AFTER `bw.Flush` returns to the client. Identical fix to
   `TestWriteBufferPoolHijackOnly` (efebbba): `handlerDone` channel
   sync so the test waits for the user handler function to return.

2. **`TestNativeEngineCloseFrameEcho/io_uring/7.7.9`** (Test job) —
   detached close-handshake race. The WS middleware queues a close-
   frame echo then calls `SetWSIdleDeadline(1)` so the engine drops
   the FD. On epoll the subsequent `closeConn` always races AFTER
   the synchronous `unix.Write` flush — fine. On iouring `flushSend`
   submits a SEND SQE asynchronously; `closeConn` for a detached
   connection jumped straight to `finishCloseDetached` (SHUT_WR +
   close), tearing the FD down before the SEND completed. Move the
   `cs.closing = true` defer above the detached branch so WS/SSE
   connections get the same deferred-close semantics, then dispatch
   the eventual close through a new `finishCloseAny` helper.

3. **`TestAdaptiveConstrainedRing`** (Integration job) — Azure CI
   ACCEPT_DIRECT EINVAL during io_uring stabilization races the first
   client request, giving a one-shot `connection reset by peer`. Same
   retry-with-backoff pattern already used by
   `TestAdaptiveAutoSingleWorker` (88c92b2 / f912fd4).

## Test plan
- [x] `go test -race -count=500 -run TestWriteBufferPool$ ./middleware/websocket/` clean
- [x] `go test -race -timeout 180s ./engine/epoll/ ./engine/iouring/ ./middleware/websocket/ ./test/integration/` on linux/arm64 docker clean
- [x] Build darwin + linux
- [ ] CI green on all 10 jobs