### PR TITLE
fix(release): bump celeris pin v1.4.1 → v1.4.2 in all submodule go.mods

### DIFF
--- a/middleware/compress/go.mod
+++ b/middleware/compress/go.mod
@@ -4,7 +4,7 @@ go 1.26.3
 
 require (
 	github.com/andybalholm/brotli v1.2.1
-	github.com/goceleris/celeris v1.4.1
+	github.com/goceleris/celeris v1.4.2
 	github.com/klauspost/compress v1.18.6
 )
 

--- a/middleware/metrics/go.mod
+++ b/middleware/metrics/go.mod
@@ -3,7 +3,7 @@ module github.com/goceleris/celeris/middleware/metrics
 go 1.26.3
 
 require (
-	github.com/goceleris/celeris v1.4.1
+	github.com/goceleris/celeris v1.4.2
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.5

--- a/middleware/otel/go.mod
+++ b/middleware/otel/go.mod
@@ -3,7 +3,7 @@ module github.com/goceleris/celeris/middleware/otel
 go 1.26.3
 
 require (
-	github.com/goceleris/celeris v1.4.1
+	github.com/goceleris/celeris v1.4.2
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0

--- a/middleware/protobuf/go.mod
+++ b/middleware/protobuf/go.mod
@@ -3,7 +3,7 @@ module github.com/goceleris/celeris/middleware/protobuf
 go 1.26.3
 
 require (
-	github.com/goceleris/celeris v1.4.1
+	github.com/goceleris/celeris v1.4.2
 	google.golang.org/protobuf v1.36.11
 )
 

--- a/test/benchcmp_sse/go.mod
+++ b/test/benchcmp_sse/go.mod
@@ -3,7 +3,7 @@ module github.com/goceleris/celeris/test/benchcmp_sse
 go 1.26.3
 
 require (
-	github.com/goceleris/celeris v1.4.1
+	github.com/goceleris/celeris v1.4.2
 	github.com/tmaxmax/go-sse v0.11.0
 )
 

--- a/test/benchcmp_ws/go.mod
+++ b/test/benchcmp_ws/go.mod
@@ -3,7 +3,7 @@ module github.com/goceleris/celeris/test/benchcmp_ws
 go 1.26.3
 
 require (
-	github.com/goceleris/celeris v1.4.1
+	github.com/goceleris/celeris v1.4.2
 	github.com/gorilla/websocket v1.5.3
 )
 

--- a/test/perfmatrix/README.md
+++ b/test/perfmatrix/README.md
@@ -7,9 +7,10 @@ and optionally captures pprof per cell.
 
 ## Status
 
-Scaffold only (v1.4.1). Interfaces and package structure are stable; server
-implementations, scenarios, and the orchestrator body are filled in by
-wave-2 and wave-3 agents.
+Production. Drives `mage matrixBench` and `mage matrixBenchStrict` for
+release-gate validation. Scenarios, competitor servers (chi, echo,
+fasthttp, fiber, gin, hertz, iris, stdhttp), and driver-backed cells
+(postgres, redis, memcached) are all implemented.
 
 ## Why a separate submodule?
 

--- a/test/perfmatrix/go.mod
+++ b/test/perfmatrix/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cloudwego/hertz v0.10.4
 	github.com/gin-gonic/gin v1.12.0
 	github.com/go-chi/chi/v5 v5.2.5
-	github.com/goceleris/celeris v1.4.1
+	github.com/goceleris/celeris v1.4.2
 	github.com/goceleris/loadgen v1.4.3
 	github.com/gofiber/fiber/v3 v3.2.0
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
## Summary

The v1.4.2 release-tagging workflow flagged 4 middleware submodules
(`compress`, `metrics`, `otel`, `protobuf`) with stale celeris v1.4.1
pins in their `go.mod`. The submodule v1.4.2 tags **were** created at
the milestone commit (`3ff4f2a`), but the published go.mods would
resolve celeris to v1.4.1 for any downstream consumer doing
`go get github.com/goceleris/celeris/middleware/<X>@v1.4.2` — Go
ignores \`replace\` directives in transitive modules, so only the
\`require\` line is honoured.

## What changed

Bumped \`require github.com/goceleris/celeris\` from \`v1.4.1\` to
\`v1.4.2\` in every submodule that pinned the old version:

- \`middleware/compress/go.mod\` *(release blocker — flagged by tagging tool)*
- \`middleware/metrics/go.mod\` *(release blocker — flagged by tagging tool)*
- \`middleware/otel/go.mod\` *(release blocker — flagged by tagging tool)*
- \`middleware/protobuf/go.mod\` *(release blocker — flagged by tagging tool)*
- \`test/benchcmp_sse/go.mod\` *(consistency — bench-only, not externally tagged)*
- \`test/benchcmp_ws/go.mod\` *(consistency — bench-only, not externally tagged)*
- \`test/perfmatrix/go.mod\` *(consistency — bench-only, not externally tagged)*

\`go mod tidy\` is clean on all 7 — only the require line moves, zero
transitive-dep churn.

## What was deliberately NOT touched

- \`test/drivercmp/{redis,postgres,memcached}\` use \`celeris v0.0.0\` +
  local-\`replace\` placeholders. Bench-only, never tagged externally.
  The \`v0.0.0\` placeholder is intentional and stays.
- Historical comments documenting past releases (\`// fixed in v1.3.4\`,
  \`--- v1.2.4 celeristest option tests ---\`, \`// since v1.3.4\`) —
  these document genealogy and \"why-this-code\" context. Removing them
  would erase useful narrative without providing any release benefit.
  If you want them rewritten/generalised, say the word and I'll do a
  follow-up PR scoped to documentation cleanup.

## Test plan

- [x] \`go mod tidy\` clean on all 7 submodules
- [x] \`go build ./...\` clean on all 7 submodules
- [ ] CI green on this PR
- [ ] After merge: delete the existing v1.4.2 submodule tags
      (\`middleware/{compress,metrics,otel,protobuf}/v1.4.2\`) and the
      root \`v1.4.2\` tag, then re-tag the new HEAD so published
      modules resolve celeris@v1.4.2 correctly.

## Closes

- Related to release of v1.4.2 milestone (#262)