### PR TITLE
feat: -tags=validation build with in-process assertion counters

### DIFF
--- a/adaptive/engine.go
+++ b/adaptive/engine.go
@@ -327,6 +327,14 @@ func (e *Engine) performSwitch() {
 	}
 	e.switchMu.Unlock()
 
+	// validateSwitch is a no-op in production (see
+	// validation_default.go); under -tags=validation it asserts the
+	// pre/post-switch FD invariant and increments
+	// validation.AdaptiveSwitchFDLeaks on violation. Snapshot
+	// metrics on both engines so the post-switch check can see the
+	// full connection accounting from both halves of the swap.
+	preMetrics := e.Metrics()
+
 	// Resume new active BEFORE pausing old — this creates a brief overlap
 	// where both engines listen (via SO_REUSEPORT), which is correct. The
 	// alternative (pause first) creates a window where NEITHER listens,
@@ -354,6 +362,8 @@ func (e *Engine) performSwitch() {
 	if ac, ok := newStandby.(engine.AcceptController); ok {
 		_ = ac.PauseAccept()
 	}
+
+	validateSwitch(preMetrics, e.Metrics())
 
 	e.logger.Info("engine switch completed",
 		"now_active", newActive.Type().String(),

--- a/adaptive/validation_check.go
+++ b/adaptive/validation_check.go
@@ -1,0 +1,41 @@
+//go:build linux && validation
+
+package adaptive
+
+import (
+	"github.com/goceleris/celeris/engine"
+	"github.com/goceleris/celeris/validation"
+)
+
+// validateSwitch is invoked at the switch boundary in performSwitch
+// with the engine-metrics snapshots taken immediately before
+// ResumeAccept on the new active and immediately after PauseAccept
+// on the old active. The wave-7 invariant is:
+//
+//	pre.ActiveConnections ⊆ post.ActiveConnections ∪ closed-during-switch
+//
+// Without per-FD identity to enumerate the actual sets we approximate
+// the invariant numerically: a switch must not orphan more
+// connections than legitimately closed during the swap. The
+// "legitimate" close budget is bounded by the request count delta —
+// if zero new requests landed during the swap, no in-flight close
+// should be possible either. Conversely, a positive RequestCount
+// delta admits up to that many close events.
+//
+// We increment validation.AdaptiveSwitchFDLeaks when
+//
+//	post.ActiveConnections + (post.RequestCount - pre.RequestCount)
+//	  < pre.ActiveConnections
+//
+// — i.e. fewer connections survived than the request-served budget
+// can account for. Probatorium's switch-FD-leak property reads the
+// counter via the unix socket after each adaptive churn cell.
+func validateSwitch(pre, post engine.EngineMetrics) {
+	served := uint64(0)
+	if post.RequestCount > pre.RequestCount {
+		served = post.RequestCount - pre.RequestCount
+	}
+	if post.ActiveConnections+int64(served) < pre.ActiveConnections {
+		validation.AdaptiveSwitchFDLeaks.Add(1)
+	}
+}

--- a/adaptive/validation_default.go
+++ b/adaptive/validation_default.go
@@ -1,0 +1,13 @@
+//go:build linux && !validation
+
+package adaptive
+
+import "github.com/goceleris/celeris/engine"
+
+// validateSwitch is the production no-op stub. Inlines to nothing
+// — performSwitch pays zero overhead in production builds. The
+// assertion-bearing implementation lives in validation_check.go and
+// is compiled under -tags=validation.
+//
+//go:inline
+func validateSwitch(_, _ engine.EngineMetrics) {}

--- a/cmd/celeris/main.go
+++ b/cmd/celeris/main.go
@@ -1,0 +1,57 @@
+// Command celeris is a minimal launcher around the celeris HTTP
+// server, primarily intended as the entry point for validation soak
+// runs. Production deployments should embed celeris.New directly
+// rather than depend on this binary.
+//
+// Under the validation build tag the launcher additionally binds a
+// unix-domain socket at /tmp/celeris-validation.sock that streams
+// assertion counters as JSON. See main_validation.go and the
+// validation package for details.
+package main
+
+import (
+	"context"
+	"flag"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/goceleris/celeris"
+)
+
+func main() {
+	addr := flag.String("addr", ":0", "address to listen on (host:port, :0 for OS-assigned)")
+	flag.Parse()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	srv := celeris.New(celeris.Config{
+		Addr:   *addr,
+		Logger: logger,
+	})
+	srv.GET("/", func(c *celeris.Context) error {
+		return c.String(200, "celeris ok\n")
+	})
+
+	stopValidation, err := startValidationEndpoint(logger)
+	if err != nil {
+		logger.Error("validation endpoint start failed", "err", err)
+		os.Exit(1)
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.StartWithContext(ctx) }()
+
+	select {
+	case <-ctx.Done():
+	case err := <-errCh:
+		if err != nil {
+			logger.Error("server exited", "err", err)
+		}
+	}
+
+	stopValidation()
+}

--- a/cmd/celeris/main_default.go
+++ b/cmd/celeris/main_default.go
@@ -1,0 +1,13 @@
+//go:build !validation
+
+package main
+
+import "log/slog"
+
+// startValidationEndpoint is the production no-op: production
+// binaries do NOT expose the unix socket and do NOT carry the
+// assertion counters. Returns a no-op stop callback so main.go can
+// defer it unconditionally.
+func startValidationEndpoint(_ *slog.Logger) (func(), error) {
+	return func() {}, nil
+}

--- a/cmd/celeris/main_validation.go
+++ b/cmd/celeris/main_validation.go
@@ -1,0 +1,33 @@
+//go:build validation
+
+package main
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/goceleris/celeris/validation"
+)
+
+// startValidationEndpoint binds the unix socket at
+// validation.SocketPath and starts the JSON snapshot server.
+// Returns a stop callback that cleanly shuts the listener down and
+// removes the socket inode on process exit (defer rm contract from
+// the wave-7 spec).
+func startValidationEndpoint(logger *slog.Logger) (func(), error) {
+	ep, err := validation.StartEndpoint()
+	if err != nil {
+		return nil, err
+	}
+	logger.Info("validation endpoint listening",
+		"socket", validation.SocketPath,
+	)
+	return func() {
+		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := ep.Stop(shutCtx); err != nil {
+			logger.Warn("validation endpoint stop", "err", err)
+		}
+	}, nil
+}

--- a/engine/iouring/ring.go
+++ b/engine/iouring/ring.go
@@ -254,6 +254,11 @@ func (r *Ring) GetSQE() unsafe.Pointer {
 		atomic.StoreUint32((*uint32)(r.sqTail), tail+1)
 	}
 	r.pending++
+	// validateSQEWrite is a no-op in production (see
+	// validation_default.go); under -tags=validation it asserts
+	// monotonic tail across all GetSQE callers and increments
+	// validation.IouringSQECorruptions on violation.
+	validateSQEWrite(r, tail+1)
 	return sqePtr
 }
 

--- a/engine/iouring/validation_check.go
+++ b/engine/iouring/validation_check.go
@@ -1,0 +1,49 @@
+//go:build linux && validation
+
+package iouring
+
+import (
+	"sync/atomic"
+
+	"github.com/goceleris/celeris/validation"
+)
+
+// lastSQEWriteTail tracks the highest SQE tail value previously
+// observed inside GetSQE. The wave-7 invariant is: the ring's tail
+// is strictly monotonic from any one issuer thread (single-issuer
+// rings) and never decreases overall (multi-issuer rings, modulo
+// wrap). A drop in the observed tail means another goroutine raced
+// with the issuer that owns this ring — exactly the failure mode
+// that PR #36's send-queue corruption bug exhibited.
+//
+// We use a single global atomic rather than per-Ring state so the
+// counter increments on any cross-thread anomaly regardless of which
+// Ring instance hit it. The validator-checker downstream maps this
+// counter to the "no SQE corruption" property predicate.
+var lastSQEWriteTail atomic.Uint32
+
+// validateSQEWrite is invoked from GetSQE after it advances the SQ
+// tail. The supplied tail is the post-advance value (i.e. the index
+// just past the SQE we returned). If a later call observes a lower
+// tail than a previous call, the increment was non-monotonic
+// — exactly the violation the production-readiness audit said the
+// validation harness must catch.
+//
+// We allow tail < prev when the gap is large (wrap of the 32-bit
+// counter). A naive less-than check would false-positive on every
+// 2^32 SQEs. The wave-7 builds run for hours, not weeks, so a real
+// wrap is unreachable; treat any prev > tail with prev-tail < 2^31
+// as a violation.
+func validateSQEWrite(_ *Ring, tail uint32) {
+	for {
+		prev := lastSQEWriteTail.Load()
+		if tail >= prev || prev-tail >= 1<<31 {
+			if lastSQEWriteTail.CompareAndSwap(prev, tail) {
+				return
+			}
+			continue
+		}
+		validation.IouringSQECorruptions.Add(1)
+		return
+	}
+}

--- a/engine/iouring/validation_default.go
+++ b/engine/iouring/validation_default.go
@@ -1,0 +1,11 @@
+//go:build linux && !validation
+
+package iouring
+
+// validateSQEWrite is the production no-op stub. Inlines to nothing
+// — GetSQE pays zero overhead in production builds. See
+// validation_check.go for the assertion-bearing implementation
+// compiled in under `-tags=validation`.
+//
+//go:inline
+func validateSQEWrite(_ *Ring, _ uint32) {}

--- a/handler.go
+++ b/handler.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/goceleris/celeris/internal/ctxkit"
 	"github.com/goceleris/celeris/protocol/h2/stream"
+	"github.com/goceleris/celeris/validation"
 )
 
 type routerAdapter struct {
@@ -197,6 +198,11 @@ func (a *routerAdapter) recoverAndRelease(c *Context, s *stream.Stream) {
 //
 //go:noinline
 func (a *routerAdapter) handlePanic(c *Context, s *stream.Stream, r any) {
+	// validation.PanicCount is a no-op counter in production (zero-cost
+	// stub from validation/disabled.go); under -tags=validation it
+	// becomes a real atomic.Uint64 that probatorium reads via the unix
+	// socket to assert that no panics escape the recover safety net.
+	validation.PanicCount.Add(1)
 	a.server.logger().Error("handler panic recovered",
 		"error", fmt.Sprint(r),
 		"method", c.method,

--- a/middleware/jwt/jwt.go
+++ b/middleware/jwt/jwt.go
@@ -148,6 +148,12 @@ func New(config ...Config) celeris.HandlerFunc {
 			successHandler(c)
 		}
 
+		// validateAdmission is a no-op in production (see
+		// validation_default.go); under -tags=validation it asserts
+		// exp >= now() and bumps validation.JWTLateAdmits on
+		// violation. token.Claims aliases the live claims pointer.
+		validateAdmission(token.Claims)
+
 		return c.Next()
 	}
 }

--- a/middleware/jwt/validation_check.go
+++ b/middleware/jwt/validation_check.go
@@ -1,0 +1,64 @@
+//go:build validation
+
+package jwt
+
+import (
+	"time"
+
+	"github.com/goceleris/celeris/middleware/jwt/internal/jwtparse"
+	"github.com/goceleris/celeris/validation"
+)
+
+// validateAdmission asserts the invariant exp >= now() at the moment
+// the JWT middleware admits the request. The library's parser
+// already rejects expired tokens before they reach the admit site —
+// this check exists to catch the race window between the parser's
+// time.Now() read and the c.Next() dispatch, plus the more
+// catastrophic case of an exp claim that the parser somehow ignored
+// (e.g. a custom claims type that returns nil from Valid).
+//
+// Late admits are bumped on validation.JWTLateAdmits so probatorium's
+// jwt-late-admit predicate observes the discrepancy.
+func validateAdmission(c jwtparse.Claims) {
+	if c == nil {
+		return
+	}
+	now := time.Now()
+	switch v := c.(type) {
+	case *jwtparse.RegisteredClaims:
+		if v.ExpiresAt != nil && now.After(v.ExpiresAt.Time) {
+			validation.JWTLateAdmits.Add(1)
+		}
+	case jwtparse.MapClaims:
+		exp, ok := mapClaimsExp(v)
+		if !ok {
+			return
+		}
+		if now.Unix() > exp {
+			validation.JWTLateAdmits.Add(1)
+		}
+	}
+}
+
+// mapClaimsExp pulls the exp claim from a MapClaims as int64 seconds
+// since epoch. JSON-decoded numerics arrive as float64; explicit
+// constructions accept int / int64 too. Returns ok=false when the
+// claim is absent or carries an unexpected type — in either case the
+// assertion is a no-op (the harness's "no late admit" predicate
+// degrades to a vacuous truth when exp is unset).
+func mapClaimsExp(m jwtparse.MapClaims) (int64, bool) {
+	v, ok := m["exp"]
+	if !ok {
+		return 0, false
+	}
+	switch t := v.(type) {
+	case float64:
+		return int64(t), true
+	case int64:
+		return t, true
+	case int:
+		return int64(t), true
+	default:
+		return 0, false
+	}
+}

--- a/middleware/jwt/validation_default.go
+++ b/middleware/jwt/validation_default.go
@@ -1,0 +1,13 @@
+//go:build !validation
+
+package jwt
+
+import "github.com/goceleris/celeris/middleware/jwt/internal/jwtparse"
+
+// validateAdmission is the production no-op stub. Inlines to nothing
+// — the JWT admit hot path pays zero overhead in production builds.
+// The assertion-bearing implementation lives in validation_check.go
+// and is compiled under -tags=validation.
+//
+//go:inline
+func validateAdmission(_ jwtparse.Claims) {}

--- a/middleware/ratelimit/shard.go
+++ b/middleware/ratelimit/shard.go
@@ -248,6 +248,10 @@ func (l *shardedLimiter) allow(key string, now int64) (bool, int, int64) {
 	b.tokens--
 	remaining := int(b.tokens)
 	reset := now + int64(float64(time.Second)/l.rps)
+	// validateBucket is a no-op in production builds; under
+	// -tags=validation it asserts 0 <= tokens <= burst and bumps
+	// validation.RatelimitTokenViolations on violation.
+	validateBucket(b.tokens, l.burst)
 	s.mu.Unlock()
 	return true, remaining, reset
 }
@@ -262,6 +266,7 @@ func (l *shardedLimiter) undo(key string) {
 		if b.tokens > float64(l.burst) {
 			b.tokens = float64(l.burst)
 		}
+		validateBucket(b.tokens, l.burst)
 	}
 	s.mu.Unlock()
 }

--- a/middleware/ratelimit/validation_check.go
+++ b/middleware/ratelimit/validation_check.go
@@ -1,0 +1,20 @@
+//go:build validation
+
+package ratelimit
+
+import "github.com/goceleris/celeris/validation"
+
+// validateBucket asserts the token-bucket invariant
+// 0 <= tokens <= burst after every allow/undo update.
+//
+// A negative count means the limiter handed out more tokens than it
+// owned (concurrency bug in the shard locking). A count above burst
+// means undo over-refilled (also a concurrency bug, or a wrong cap
+// computation). Either case increments
+// validation.RatelimitTokenViolations so the property-test harness
+// flags the build.
+func validateBucket(tokens float64, burst int) {
+	if tokens < 0 || tokens > float64(burst) {
+		validation.RatelimitTokenViolations.Add(1)
+	}
+}

--- a/middleware/ratelimit/validation_default.go
+++ b/middleware/ratelimit/validation_default.go
@@ -1,0 +1,11 @@
+//go:build !validation
+
+package ratelimit
+
+// validateBucket is the production no-op stub. Inlines to nothing —
+// the allow/undo hot paths pay zero overhead in production builds.
+// The assertion-bearing implementation lives in validation_check.go
+// and is compiled under -tags=validation.
+//
+//go:inline
+func validateBucket(_ float64, _ int) {}

--- a/middleware/recovery/recovery.go
+++ b/middleware/recovery/recovery.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 
 	"github.com/goceleris/celeris"
+	"github.com/goceleris/celeris/validation"
 )
 
 var (
@@ -78,6 +79,11 @@ func New(config ...Config) celeris.HandlerFunc {
 				if err, ok := r.(error); ok && errors.Is(err, http.ErrAbortHandler) {
 					panic(r)
 				}
+
+				// validation.PanicCount is a zero-cost no-op in
+				// production builds; under -tags=validation it backs
+				// probatorium's "no panic escaped recovery" predicate.
+				validation.PanicCount.Add(1)
 
 				panicVal := formatPanic(r)
 

--- a/middleware/session/session.go
+++ b/middleware/session/session.go
@@ -506,6 +506,12 @@ func newMiddleware(cfg Config) celeris.HandlerFunc {
 
 		c.Set(ContextKey, sess)
 
+		// validateAdmission is a no-op in production (see
+		// validation_default.go); under -tags=validation it asserts
+		// session-owner binding and increments
+		// validation.SessionOwnerMismatches on violation.
+		validateAdmission(sess)
+
 		chainErr := c.Next()
 
 		if sess.destroyed {

--- a/middleware/session/validation_check.go
+++ b/middleware/session/validation_check.go
@@ -1,0 +1,49 @@
+//go:build validation
+
+package session
+
+import "github.com/goceleris/celeris/validation"
+
+// ownerKey is the well-known map key that the property-test harness
+// (and probatorium-driven fixtures) write into session data when they
+// want validateAdmission to verify session→user binding. If the key
+// is absent, the assertion site degrades to an ID-shape check only.
+const ownerKey = "_owner"
+
+// expectedOwnerKey is the parallel "ground truth" key the test
+// fixture writes into the session right before exercising the
+// middleware. A mismatch between data[ownerKey] and
+// data[expectedOwnerKey] means the session was admitted on behalf of
+// a different user than the one the harness expected — exactly the
+// scenario probatorium's session-owner-binding property checks.
+const expectedOwnerKey = "_expected_owner"
+
+// validateAdmission asserts the invariants every admitted session
+// must satisfy:
+//
+//  1. id is non-empty and well-formed (matches validSessionID)
+//  2. if both _owner and _expected_owner are present, they are equal
+//
+// Either failure increments validation.SessionOwnerMismatches so the
+// harness's session-owner-binding predicate observes the discrepancy
+// over the unix socket.
+func validateAdmission(s *Session) {
+	if s == nil {
+		return
+	}
+	if s.id == "" || !validSessionID(s.id) {
+		validation.SessionOwnerMismatches.Add(1)
+		return
+	}
+	if s.data == nil {
+		return
+	}
+	expected, hasExp := s.data[expectedOwnerKey]
+	if !hasExp {
+		return
+	}
+	actual, hasOwner := s.data[ownerKey]
+	if !hasOwner || actual != expected {
+		validation.SessionOwnerMismatches.Add(1)
+	}
+}

--- a/middleware/session/validation_default.go
+++ b/middleware/session/validation_default.go
@@ -1,0 +1,11 @@
+//go:build !validation
+
+package session
+
+// validateAdmission is the production no-op stub. Inlines to nothing
+// — the session admission hot path pays zero overhead in production
+// builds. The assertion-bearing implementation lives in
+// validation_check.go and is compiled under -tags=validation.
+//
+//go:inline
+func validateAdmission(_ *Session) {}

--- a/observe/collector.go
+++ b/observe/collector.go
@@ -28,6 +28,15 @@ type EngineMetrics = engine.EngineMetrics
 
 // Snapshot is a point-in-time copy of all collected metrics. All fields are
 // read-only values captured at the moment Collector.Snapshot was called.
+//
+// Snapshot embeds validationFields, which is defined in
+// collector_validation.go under -tags=validation to carry the
+// ValidationCounters field, and in collector_default.go as an empty
+// struct so production binaries don't pay for the extra word. Callers
+// running under -tags=validation reach the counters as
+// snapshot.ValidationCounters; production callers cannot reference
+// the field name at all (compile error), which is the explicit
+// contract — see validation/doc.go.
 type Snapshot struct {
 	// RequestsTotal is the cumulative number of handled requests.
 	RequestsTotal uint64
@@ -46,6 +55,8 @@ type Snapshot struct {
 	// CPUUtilization is the system CPU utilization as a fraction [0.0, 1.0].
 	// Returns -1 if no CPU monitor is configured or sampling failed.
 	CPUUtilization float64
+
+	validationFields
 }
 
 // CPUMonitor provides CPU utilization sampling. Implementations are
@@ -200,5 +211,10 @@ func (c *Collector) Snapshot() Snapshot {
 			snap.CPUUtilization = util
 		}
 	}
+	// fillValidation is a no-op in production builds (see
+	// collector_default.go); under -tags=validation it copies the
+	// atomic counters from the validation package into the
+	// snapshot's embedded validationFields.
+	snap.fillValidation()
 	return snap
 }

--- a/observe/collector_default.go
+++ b/observe/collector_default.go
@@ -1,0 +1,17 @@
+//go:build !validation
+
+package observe
+
+// validationFields is an empty struct in production builds. Embedding
+// an empty struct adds zero size to Snapshot, so callers reading the
+// other fields pay no cost. Attempting to reference
+// snapshot.ValidationCounters in a production build is a compile
+// error — the explicit hardening contract from validation/doc.go.
+type validationFields struct{}
+
+// fillValidation is the production no-op. The validation-tagged
+// override in collector_validation.go fills the embedded fields from
+// the live atomic counters.
+//
+//go:inline
+func (s *Snapshot) fillValidation() {}

--- a/observe/collector_validation.go
+++ b/observe/collector_validation.go
@@ -1,0 +1,23 @@
+//go:build validation
+
+package observe
+
+import "github.com/goceleris/celeris/validation"
+
+// validationFields is embedded into Snapshot under -tags=validation
+// so external callers (probatorium's validator-checker) can read the
+// validation counters off the same Snapshot value returned by
+// Collector.Snapshot. In production builds the symmetric type in
+// collector_default.go is an empty struct — the field name is then
+// inaccessible, which is the explicit hardening contract.
+type validationFields struct {
+	// ValidationCounters carries the snapshot of all assertion
+	// counters maintained under -tags=validation. JSON-serializable.
+	ValidationCounters validation.Counters `json:"validation_counters"`
+}
+
+// fillValidation populates the validation half of a Snapshot from
+// the live atomic counters. Called by Collector.Snapshot.
+func (s *Snapshot) fillValidation() {
+	s.ValidationCounters = validation.Snapshot()
+}

--- a/server_validation_test.go
+++ b/server_validation_test.go
@@ -1,0 +1,38 @@
+//go:build validation
+
+package celeris
+
+import (
+	"context"
+	"testing"
+
+	"github.com/goceleris/celeris/validation"
+)
+
+// TestServerPanicBumpsValidationCounter is the integration version of
+// the synthetic panic check from the wave-7 acceptance criteria. It
+// exercises the same safety net as TestServerPanicRecovery, then
+// verifies the cross-package wiring into validation.PanicCount.
+func TestServerPanicBumpsValidationCounter(t *testing.T) {
+	before := validation.PanicCount.Load()
+
+	s := New(Config{})
+	s.GET("/panic", func(_ *Context) error {
+		panic("handler panic — validation soak fixture")
+	})
+	adapter := &routerAdapter{server: s}
+
+	st, rw := newTestStream("GET", "/panic")
+	if err := adapter.HandleStream(context.Background(), st); err != nil {
+		t.Fatalf("HandleStream: %v", err)
+	}
+	if rw.status != 500 {
+		t.Fatalf("status: got %d, want 500", rw.status)
+	}
+	st.Release()
+
+	after := validation.PanicCount.Load()
+	if after != before+1 {
+		t.Fatalf("validation.PanicCount: got %d, want %d (before=%d)", after, before+1, before)
+	}
+}

--- a/validation/assertions.go
+++ b/validation/assertions.go
@@ -1,0 +1,60 @@
+//go:build validation
+
+package validation
+
+import "sync/atomic"
+
+// PanicCount tracks recovered panics observed by the safety net in
+// celeris.routerAdapter.recoverAndRelease and by middleware/recovery.
+var PanicCount atomic.Uint64
+
+// RaceFires is reserved for future use by sites that catch concurrent
+// access bugs at runtime (e.g. atomic.CompareAndSwap mismatches that
+// indicate a missing lock).
+var RaceFires atomic.Uint64
+
+// RatelimitTokenViolations counts token-bucket invariant breaches
+// observed at the allow/undo sites in middleware/ratelimit: token
+// count outside [0, capacity], or undo restoring above capacity.
+var RatelimitTokenViolations atomic.Uint64
+
+// SessionOwnerMismatches counts cases where the session admitted on
+// the request did not carry the owner that the validation harness
+// asserted (e.g. session id reused across logical users).
+var SessionOwnerMismatches atomic.Uint64
+
+// JWTLateAdmits counts JWTs that the middleware admitted with an
+// effective exp claim earlier than the wall-clock time at admission.
+var JWTLateAdmits atomic.Uint64
+
+// IouringSQECorruptions counts SQE write-site violations: non-monotonic
+// write index, or CQE user_data references that don't resolve to a
+// live conn.
+var IouringSQECorruptions atomic.Uint64
+
+// AdaptiveSwitchFDLeaks counts cases where the post-switch FD set is
+// not a superset of the pre-switch set minus FDs closed during the
+// switch — i.e. a connection was orphaned across the engine swap.
+var AdaptiveSwitchFDLeaks atomic.Uint64
+
+// Snapshot returns a value-typed copy of the counters at the moment
+// of the call. Each Load is independent so the snapshot is not a
+// consistent slice of a single instant, but counters monotonically
+// increase, so a stale read can only undercount — never overcount.
+func Snapshot() Counters {
+	return Counters{
+		PanicCount:               PanicCount.Load(),
+		RaceFires:                RaceFires.Load(),
+		RatelimitTokenViolations: RatelimitTokenViolations.Load(),
+		SessionOwnerMismatches:   SessionOwnerMismatches.Load(),
+		JWTLateAdmits:            JWTLateAdmits.Load(),
+		IouringSQECorruptions:    IouringSQECorruptions.Load(),
+		AdaptiveSwitchFDLeaks:    AdaptiveSwitchFDLeaks.Load(),
+	}
+}
+
+// Enabled reports whether this build has the validation tag enabled.
+// Always true under //go:build validation; the stub in disabled.go
+// returns false. Callers use this to gate test fixtures that should
+// only run under validation builds.
+func Enabled() bool { return true }

--- a/validation/counters.go
+++ b/validation/counters.go
@@ -1,0 +1,24 @@
+package validation
+
+// Counters is the JSON-serializable shape returned by Snapshot.
+//
+// Defined unconditionally so external callers (probatorium's
+// validator-checker, callers in observe.Snapshot) can reference the
+// type regardless of build tag. In a production build the values are
+// always zero; in a validation build the values are loaded from the
+// per-counter atomics in assertions.go.
+type Counters struct {
+	PanicCount               uint64 `json:"panic_count"`
+	RaceFires                uint64 `json:"race_fires"`
+	RatelimitTokenViolations uint64 `json:"ratelimit_token_violations"`
+	SessionOwnerMismatches   uint64 `json:"session_owner_mismatches"`
+	JWTLateAdmits            uint64 `json:"jwt_late_admits"`
+	IouringSQECorruptions    uint64 `json:"iouring_sqe_corruptions"`
+	AdaptiveSwitchFDLeaks    uint64 `json:"adaptive_switch_fd_leaks"`
+}
+
+// SocketPath is the hard-coded unix-socket path the validation
+// endpoint listens on. Not configurable on purpose: probatorium's
+// validator-checker compiles in the same constant so misconfiguration
+// cannot silently disable the cross-process predicate feed.
+const SocketPath = "/tmp/celeris-validation.sock"

--- a/validation/disabled.go
+++ b/validation/disabled.go
@@ -1,0 +1,36 @@
+//go:build !validation
+
+package validation
+
+// counter is the no-op stub installed in production builds. It carries
+// no state, exposes the same Add/Load/Store surface as atomic.Uint64,
+// and inlines to nothing. Importers (engine/iouring, middleware/...)
+// can therefore call validation.X.Add(1) without a build-tag guard at
+// the call site — production simply discards the increment.
+type counter struct{}
+
+func (counter) Add(uint64) uint64 { return 0 }
+func (counter) Load() uint64      { return 0 }
+func (counter) Store(uint64)      {}
+
+// PanicCount and friends are the stub instances. Same identifier
+// surface as the atomic.Uint64 vars in assertions.go so call sites
+// compile identically in both modes.
+var (
+	PanicCount               counter
+	RaceFires                counter
+	RatelimitTokenViolations counter
+	SessionOwnerMismatches   counter
+	JWTLateAdmits            counter
+	IouringSQECorruptions    counter
+	AdaptiveSwitchFDLeaks    counter
+)
+
+// Snapshot returns the zero value in production builds — no counters
+// exist and no socket is served. Kept defined so observe.Snapshot can
+// embed Counters unconditionally without a build-tag split.
+func Snapshot() Counters { return Counters{} }
+
+// Enabled reports whether this build has the validation tag enabled.
+// Always false in production.
+func Enabled() bool { return false }

--- a/validation/doc.go
+++ b/validation/doc.go
@@ -1,0 +1,18 @@
+// Package validation exposes in-process assertion counters that the
+// celeris engine and middleware bump under the `validation` build tag.
+//
+// Production binaries (built without the tag) compile against the
+// no-op stubs in disabled.go, so the counters and the unix-socket
+// endpoint are stripped at compile time — no allocations, no atomic
+// adds, no goroutines. Validation builds (-tags=validation) compile
+// against assertions.go and endpoint.go, exposing the counters as
+// atomic.Uint64 and serving a JSON snapshot over
+// /tmp/celeris-validation.sock.
+//
+// External property-test harnesses (probatorium's
+// cmd/validator-checker) read the socket on every poll to feed
+// property predicates. The counter shape is stable across both build
+// modes via the [Counters] struct and the [Snapshot] function — the
+// only thing that changes is whether reads return live atomics or
+// the zero value.
+package validation

--- a/validation/endpoint.go
+++ b/validation/endpoint.go
@@ -1,0 +1,126 @@
+//go:build validation
+
+package validation
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Endpoint serves the snapshot over a unix-domain socket. There is at
+// most one Endpoint per process; StartEndpoint enforces that with a
+// package-level singleton. The socket path is the hard-coded
+// SocketPath constant — not configurable, not exposed in production.
+type Endpoint struct {
+	listener net.Listener
+	server   *http.Server
+	done     chan struct{}
+}
+
+var (
+	endpointMu       sync.Mutex
+	endpointInstance *Endpoint
+	endpointStarted  atomic.Bool
+)
+
+// StartEndpoint binds the unix socket at SocketPath and starts an
+// HTTP server that returns Snapshot() as JSON on any GET request.
+// Calling it more than once in the same process is a no-op (returns
+// the running endpoint). The caller is expected to defer Stop on
+// clean shutdown so the socket file is removed.
+func StartEndpoint() (*Endpoint, error) {
+	endpointMu.Lock()
+	defer endpointMu.Unlock()
+
+	if endpointInstance != nil {
+		return endpointInstance, nil
+	}
+
+	// Best-effort cleanup of a stale socket from a previous crash:
+	// unix.Listen fails with "address already in use" if the inode
+	// exists, even when nothing is listening. Ignore the error from
+	// os.Remove — a missing file is the happy path, and a permission
+	// error will surface on the Listen call below with a clearer
+	// message.
+	_ = os.Remove(SocketPath)
+
+	ln, err := net.Listen("unix", SocketPath)
+	if err != nil {
+		return nil, err
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Snapshot())
+	})
+
+	srv := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 2 * time.Second,
+	}
+	ep := &Endpoint{
+		listener: ln,
+		server:   srv,
+		done:     make(chan struct{}),
+	}
+
+	go func() {
+		defer close(ep.done)
+		err := srv.Serve(ln)
+		// http.ErrServerClosed is the expected shutdown signal; any
+		// other error means the listener died unexpectedly and
+		// callers polling the socket will see ECONNREFUSED.
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			// Validation builds intentionally lack a logger
+			// dependency to keep this package leaf-level; we swallow
+			// the error rather than panic, on the principle that a
+			// dead endpoint should not crash the system under test.
+			_ = err
+		}
+	}()
+
+	endpointInstance = ep
+	endpointStarted.Store(true)
+	return ep, nil
+}
+
+// Stop shuts the endpoint down, closes the listener, and removes the
+// socket file. Safe to call from a defer; idempotent.
+func (e *Endpoint) Stop(ctx context.Context) error {
+	if e == nil {
+		return nil
+	}
+	endpointMu.Lock()
+	if endpointInstance == e {
+		endpointInstance = nil
+	}
+	endpointMu.Unlock()
+
+	err := e.server.Shutdown(ctx)
+	_ = os.Remove(SocketPath)
+	select {
+	case <-e.done:
+	case <-ctx.Done():
+	}
+	endpointStarted.Store(false)
+	return err
+}
+
+// EndpointAddr returns the unix socket address the endpoint is bound
+// to, or nil if no endpoint is running.
+func EndpointAddr() net.Addr {
+	endpointMu.Lock()
+	defer endpointMu.Unlock()
+	if endpointInstance == nil {
+		return nil
+	}
+	return endpointInstance.listener.Addr()
+}

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -1,0 +1,122 @@
+//go:build validation
+
+package validation
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// TestPanicCountIncrement is the synthetic-panic predicate from the
+// wave-7 acceptance criteria: bumping the counter directly is what
+// every higher-layer call site does, so verifying the counter
+// machinery isolates the wiring from the rest of the system.
+func TestPanicCountIncrement(t *testing.T) {
+	before := PanicCount.Load()
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				PanicCount.Add(1)
+			}
+		}()
+		panic("synthetic")
+	}()
+	after := PanicCount.Load()
+	if after != before+1 {
+		t.Fatalf("PanicCount: got %d, want %d", after, before+1)
+	}
+}
+
+// TestEndpointServesJSON binds the endpoint, makes a GET, and
+// verifies the JSON payload carries the bumped counter. The endpoint
+// path is the same hard-coded SocketPath that probatorium's
+// validator-checker reads.
+func TestEndpointServesJSON(t *testing.T) {
+	// Reset for a deterministic snapshot. The endpoint is a process
+	// singleton, so other tests must run on either side of this
+	// reset cleanly — Atomics carry no destructor, so a Store(0)
+	// here is sufficient.
+	PanicCount.Store(0)
+	RatelimitTokenViolations.Store(0)
+
+	ep, err := StartEndpoint()
+	if err != nil {
+		t.Fatalf("StartEndpoint: %v", err)
+	}
+	defer func() {
+		shutCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = ep.Stop(shutCtx)
+	}()
+
+	// Bump a couple counters and verify the JSON shape echoes them.
+	PanicCount.Add(2)
+	RatelimitTokenViolations.Add(3)
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", SocketPath)
+			},
+		},
+		Timeout: 2 * time.Second,
+	}
+	resp, err := client.Get("http://unused/")
+	if err != nil {
+		t.Fatalf("GET via unix socket: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: got %d, want 200", resp.StatusCode)
+	}
+	var got Counters
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.PanicCount != 2 {
+		t.Errorf("PanicCount: got %d, want 2", got.PanicCount)
+	}
+	if got.RatelimitTokenViolations != 3 {
+		t.Errorf("RatelimitTokenViolations: got %d, want 3", got.RatelimitTokenViolations)
+	}
+}
+
+// TestSnapshotConsistency verifies Counters fields stay in sync with
+// the package-level atomic variables. Adding a new atomic without
+// updating Snapshot would silently leave the new counter invisible
+// to probatorium; this test catches the omission.
+func TestSnapshotConsistency(t *testing.T) {
+	PanicCount.Store(11)
+	RaceFires.Store(12)
+	RatelimitTokenViolations.Store(13)
+	SessionOwnerMismatches.Store(14)
+	JWTLateAdmits.Store(15)
+	IouringSQECorruptions.Store(16)
+	AdaptiveSwitchFDLeaks.Store(17)
+	defer func() {
+		PanicCount.Store(0)
+		RaceFires.Store(0)
+		RatelimitTokenViolations.Store(0)
+		SessionOwnerMismatches.Store(0)
+		JWTLateAdmits.Store(0)
+		IouringSQECorruptions.Store(0)
+		AdaptiveSwitchFDLeaks.Store(0)
+	}()
+	got := Snapshot()
+	want := Counters{
+		PanicCount:               11,
+		RaceFires:                12,
+		RatelimitTokenViolations: 13,
+		SessionOwnerMismatches:   14,
+		JWTLateAdmits:            15,
+		IouringSQECorruptions:    16,
+		AdaptiveSwitchFDLeaks:    17,
+	}
+	if got != want {
+		t.Fatalf("Snapshot mismatch:\n got  %+v\n want %+v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `-tags=validation` build of celeris that exposes in-process assertion counters via a unix-domain socket at `/tmp/celeris-validation.sock`. Production binaries (no tag) are unchanged — the counters resolve to zero-cost no-op stubs, the socket is never created, and the cmd/celeris launcher's validation entry point compiles away.

The validation half of the new build is the data feed for probatorium's `cmd/validator-checker`, which reads the socket on every poll to drive property predicates over multi-hour soak runs.

### Wired assertion sites (each gated by `//go:build validation`)

- `engine/iouring/ring.go` — SQE tail monotonicity in `GetSQE` → `validation.IouringSQECorruptions` (PR #36 regression guard).
- `adaptive/engine.go` — pre/post-switch FD invariant in `performSwitch` → `validation.AdaptiveSwitchFDLeaks` (PR #49 regression guard).
- `handler.go` and `middleware/recovery/recovery.go` — recovered panics → `validation.PanicCount`.
- `middleware/ratelimit/shard.go` — token-bucket invariant `0 <= tokens <= burst` → `validation.RatelimitTokenViolations`.
- `middleware/session/session.go` — session-owner binding (well-formed ID + optional `_owner` ↔ `_expected_owner` match) → `validation.SessionOwnerMismatches`.
- `middleware/jwt/jwt.go` — `exp >= now()` at admit site → `validation.JWTLateAdmits`.

### Observe integration

`observe.Snapshot` embeds a build-tag-split `validationFields` struct: empty in production (zero size), `ValidationCounters validation.Counters` with JSON tag `"validation_counters"` under `-tags=validation`. Referencing `snapshot.ValidationCounters` in a production build is a compile error — the explicit hardening contract.

### Launcher

`cmd/celeris -addr=:0` is a thin server launcher. Under `-tags=validation` it additionally binds the unix socket and removes the inode on `SIGINT`/`SIGTERM`. Production builds skip both.

### Verification

- `go build ./... && go vet ./... && go test -count=1 -short ./...` → all green
- `go build -tags=validation ./... && go vet -tags=validation ./... && go test -tags=validation -count=1 -short ./...` → all green, includes 4 new validation-tagged tests (panic counter integration, snapshot consistency, unix-socket JSON round-trip, end-to-end safety net)
- `go test -tags=validation -race -count=1 -short ./validation/... ./observe/... ./middleware/ratelimit/... ./middleware/recovery/...` → race clean
- End-to-end darwin/arm64 smoke: `curl --unix-socket /tmp/celeris-validation.sock http://./` returns JSON; `SIGINT` removes the socket file

Closes goceleris/probatorium#7

## Test plan

- [x] `go build ./...` (vanilla)
- [x] `go vet ./...` (vanilla)
- [x] `go test -count=1 -short ./...` (vanilla)
- [x] `go build -tags=validation ./...`
- [x] `go vet -tags=validation ./...`
- [x] `go test -tags=validation -count=1 -short ./...`
- [x] `go test -tags=validation -race ./validation/... ./observe/... ./middleware/...`
- [x] End-to-end socket smoke test (`cmd/celeris` start → `curl` → SIGINT → socket removed)
- [ ] CI to confirm on linux/amd64 (this PR was authored on darwin/arm64)