### PR TITLE
fix: validation stubs Add() returns nothing + suppress validationFields unused

### DIFF
--- a/observe/collector.go
+++ b/observe/collector.go
@@ -56,6 +56,10 @@ type Snapshot struct {
 	// Returns -1 if no CPU monitor is configured or sampling failed.
 	CPUUtilization float64
 
+	// validationFields is empty in production builds and carries the
+	// ValidationCounters field under -tags=validation. The unused-linter
+	// doesn't track embedding-as-use, so suppress its false positive.
+	//nolint:unused // build-tag symmetry; non-empty under -tags=validation
 	validationFields
 }
 

--- a/observe/collector_default.go
+++ b/observe/collector_default.go
@@ -7,6 +7,12 @@ package observe
 // other fields pay no cost. Attempting to reference
 // snapshot.ValidationCounters in a production build is a compile
 // error — the explicit hardening contract from validation/doc.go.
+//
+// The unused-linter does not track embedding as a use, so suppress its
+// false positive: this type is referenced from collector.go's
+// embedded field, which lives on Snapshot.
+//
+//nolint:unused // embedded into Snapshot in collector.go for build-tag symmetry
 type validationFields struct{}
 
 // fillValidation is the production no-op. The validation-tagged

--- a/validation/assertions.go
+++ b/validation/assertions.go
@@ -4,38 +4,54 @@ package validation
 
 import "sync/atomic"
 
+// Counter wraps an atomic.Uint64 with a return-value-free Add so call
+// sites are `validation.X.Add(1)` without static-check tools (which
+// see the no-op stub in disabled.go) flagging an ignored return.
+type Counter struct{ v atomic.Uint64 }
+
+// Add atomically increments the counter by n. The discarded return
+// value of the underlying atomic operation is intentional — see the
+// type doc.
+func (c *Counter) Add(n uint64) { _ = c.v.Add(n) }
+
+// Load returns the current counter value.
+func (c *Counter) Load() uint64 { return c.v.Load() }
+
+// Store atomically writes the counter value.
+func (c *Counter) Store(n uint64) { c.v.Store(n) }
+
 // PanicCount tracks recovered panics observed by the safety net in
 // celeris.routerAdapter.recoverAndRelease and by middleware/recovery.
-var PanicCount atomic.Uint64
+var PanicCount Counter
 
 // RaceFires is reserved for future use by sites that catch concurrent
 // access bugs at runtime (e.g. atomic.CompareAndSwap mismatches that
 // indicate a missing lock).
-var RaceFires atomic.Uint64
+var RaceFires Counter
 
 // RatelimitTokenViolations counts token-bucket invariant breaches
 // observed at the allow/undo sites in middleware/ratelimit: token
 // count outside [0, capacity], or undo restoring above capacity.
-var RatelimitTokenViolations atomic.Uint64
+var RatelimitTokenViolations Counter
 
 // SessionOwnerMismatches counts cases where the session admitted on
 // the request did not carry the owner that the validation harness
 // asserted (e.g. session id reused across logical users).
-var SessionOwnerMismatches atomic.Uint64
+var SessionOwnerMismatches Counter
 
 // JWTLateAdmits counts JWTs that the middleware admitted with an
 // effective exp claim earlier than the wall-clock time at admission.
-var JWTLateAdmits atomic.Uint64
+var JWTLateAdmits Counter
 
 // IouringSQECorruptions counts SQE write-site violations: non-monotonic
 // write index, or CQE user_data references that don't resolve to a
 // live conn.
-var IouringSQECorruptions atomic.Uint64
+var IouringSQECorruptions Counter
 
 // AdaptiveSwitchFDLeaks counts cases where the post-switch FD set is
 // not a superset of the pre-switch set minus FDs closed during the
 // switch — i.e. a connection was orphaned across the engine swap.
-var AdaptiveSwitchFDLeaks atomic.Uint64
+var AdaptiveSwitchFDLeaks Counter
 
 // Snapshot returns a value-typed copy of the counters at the moment
 // of the call. Each Load is independent so the snapshot is not a

--- a/validation/disabled.go
+++ b/validation/disabled.go
@@ -2,28 +2,34 @@
 
 package validation
 
-// counter is the no-op stub installed in production builds. It carries
-// no state, exposes the same Add/Load/Store surface as atomic.Uint64,
-// and inlines to nothing. Importers (engine/iouring, middleware/...)
-// can therefore call validation.X.Add(1) without a build-tag guard at
-// the call site — production simply discards the increment.
-type counter struct{}
+// Counter is the no-op stub installed in production builds. It carries
+// no state and inlines to nothing. Importers (engine/iouring,
+// middleware/...) call validation.X.Add(1) without a build-tag guard at
+// the call site — production simply discards the increment. Add returns
+// nothing so static-check tools cannot flag callers for ignoring an
+// unused return value.
+type Counter struct{}
 
-func (counter) Add(uint64) uint64 { return 0 }
-func (counter) Load() uint64      { return 0 }
-func (counter) Store(uint64)      {}
+// Add is the production no-op increment.
+func (Counter) Add(uint64) {}
+
+// Load returns zero in production.
+func (Counter) Load() uint64 { return 0 }
+
+// Store is the production no-op write.
+func (Counter) Store(uint64) {}
 
 // PanicCount and friends are the stub instances. Same identifier
-// surface as the atomic.Uint64 vars in assertions.go so call sites
+// surface as the wrapped counter vars in assertions.go so call sites
 // compile identically in both modes.
 var (
-	PanicCount               counter
-	RaceFires                counter
-	RatelimitTokenViolations counter
-	SessionOwnerMismatches   counter
-	JWTLateAdmits            counter
-	IouringSQECorruptions    counter
-	AdaptiveSwitchFDLeaks    counter
+	PanicCount               Counter
+	RaceFires                Counter
+	RatelimitTokenViolations Counter
+	SessionOwnerMismatches   Counter
+	JWTLateAdmits            Counter
+	IouringSQECorruptions    Counter
+	AdaptiveSwitchFDLeaks    Counter
 )
 
 // Snapshot returns the zero value in production builds — no counters


### PR DESCRIPTION
Fixes the two staticcheck/unused classes that landed on main from PR #267.

## What broke

- `SA4017` at `handler.go:205` and `middleware/recovery/recovery.go:86` — `validation.PanicCount.Add(1)` was calling the disabled.go no-op stub `func (counter) Add(uint64) uint64`, with the return value (always 0) ignored. Statically a function with no side effects whose return is discarded.
- `unused` at `observe/collector.go:59` and `observe/collector_default.go:10` — `validationFields` (empty struct in default builds) is embedded into Snapshot but the unused-linter doesn't track embedding as a use.

## Fix

- Restructure `validation.PanicCount` etc. as a `Counter` wrapper struct in both builds. Production: `Add(uint64)` is empty. Validation: `Add(uint64)` calls `atomic.Uint64.Add(n)` and discards the return internally.
- Add `//nolint:unused` directives with reasons on the `validationFields` type and its embed site.

## Test plan

- [x] `go build ./...` clean (vanilla)
- [x] `go vet ./...` clean (vanilla)
- [x] `go test -short ./...` clean (vanilla, all packages green)
- [x] `go build -tags=validation ./...` clean
- [x] `go vet -tags=validation ./...` clean
- [x] `go test -tags=validation -short ./...` clean (validation package + observe both green)
- [x] `golangci-lint run` 0 issues
- [ ] CI green on this PR

- Closes #269