### PR TITLE
fix(engine,middleware): unblock /ws + /events on iouring + epoll (#273)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ fullstack
 *.json
 benchmark_analysis.py
 .claude/scheduled_tasks.lock
+.sse_engine_test
+.ws_engine_test

--- a/context.go
+++ b/context.go
@@ -222,7 +222,19 @@ func acquireContext(s *stream.Stream) *Context {
 func releaseContext(c *Context) {
 	// If the context is cached on the stream for reuse, reset but
 	// do not return to the pool. The stream owns its lifecycle.
-	cached := c.stream != nil && c.stream.CachedCtx == c
+	//
+	// Detached contexts (Server-Sent Events, WebSocket) are released
+	// from a goroutine that fires when the user-handler signals
+	// done(). At that point the engine's request-side stream cleanup
+	// may already be running (std engine: deferred Stream.Release in
+	// Bridge.ServeHTTP; iouring/epoll: closeConn → CloseH1 →
+	// stream.Release). Reading c.stream.CachedCtx here races those
+	// writers — and the caching optimisation is irrelevant for a
+	// detached context anyway because the conn is single-use SSE /
+	// long-lived WS, not pooled keep-alive H1. Always pool the
+	// Context directly in that case; see celeris#273 for the failure
+	// mode the race detector pinned.
+	cached := !c.detached && c.stream != nil && c.stream.CachedCtx == c
 	c.reset()
 	if !cached {
 		contextPool.Put(c)

--- a/context_response.go
+++ b/context_response.go
@@ -1284,11 +1284,11 @@ func (c *Context) SetWSIdleDeadline(ns int64) {
 // this before returning from the request handler:
 //
 //   - true:  return nil from the handler; the spawned goroutine writes
-//            via the engine's guarded write path and the engine flushes.
+//     via the engine's guarded write path and the engine flushes.
 //   - false: the spawned goroutine must complete before the handler
-//            returns (e.g. block on a done channel); otherwise the
-//            net/http server treats the response as finished and may
-//            close the conn underneath the still-running goroutine.
+//     returns (e.g. block on a done channel); otherwise the
+//     net/http server treats the response as finished and may
+//     close the conn underneath the still-running goroutine.
 //
 // Added in celeris v1.4.4 to fix the engine asymmetry that caused
 // goceleris/probatorium#103 to file celeris#273: SSE responses were

--- a/context_response.go
+++ b/context_response.go
@@ -1273,6 +1273,31 @@ func (c *Context) SetWSIdleDeadline(ns int64) {
 	}
 }
 
+// EngineSupportsAsyncDetach reports whether the active engine has the
+// machinery to keep the connection alive after the request handler
+// returns. True on native engines (epoll, io_uring) and on stream
+// transports that have wired an OnDetach hook; false on the std engine
+// (which closes the conn the moment the request handler returns).
+//
+// Middleware that spawns a goroutine to drive a long-lived stream
+// (Server-Sent Events, WebSocket, chunked progress) should consult
+// this before returning from the request handler:
+//
+//   - true:  return nil from the handler; the spawned goroutine writes
+//            via the engine's guarded write path and the engine flushes.
+//   - false: the spawned goroutine must complete before the handler
+//            returns (e.g. block on a done channel); otherwise the
+//            net/http server treats the response as finished and may
+//            close the conn underneath the still-running goroutine.
+//
+// Added in celeris v1.4.4 to fix the engine asymmetry that caused
+// goceleris/probatorium#103 to file celeris#273: SSE responses were
+// hanging on native engines because the middleware ran the user
+// handler inline and blocked the worker thread.
+func (c *Context) EngineSupportsAsyncDetach() bool {
+	return c != nil && c.stream != nil && c.stream.OnDetach != nil
+}
+
 // Detach removes the Context from the handler chain's lifecycle.
 // After Detach, the Context will not be released when the handler returns.
 // The caller MUST call the returned done function when finished with the Context —

--- a/engine/epoll/conn.go
+++ b/engine/epoll/conn.go
@@ -102,6 +102,17 @@ type connState struct {
 	// l.h2Conns — the only worker-thread-owned piece) and keep the conn
 	// alive instead of closing it.
 	asyncH2Promoted atomic.Bool
+
+	// asyncDetachUnlocked is set by OnDetach when it releases detachMu
+	// on behalf of the dispatch goroutine. runAsyncHandler observes it
+	// after ProcessH1 returns and skips the symmetric final Unlock
+	// (otherwise it would unlock an already-released mutex). Cleared by
+	// releaseConnState. See engine/iouring/conn.go for the full rationale
+	// (celeris#273) — pre-fix, /ws and /events would TIMEOUT on
+	// iouring+async or epoll+async because the dispatch goroutine
+	// deadlocked on its own re-entrant Lock attempt when the middleware
+	// emitted the 101 / SSE headers right after Detach.
+	asyncDetachUnlocked bool
 }
 
 var connStatePool = sync.Pool{
@@ -155,6 +166,7 @@ func releaseConnState(cs *connState) {
 	cs.asyncOutBuf = cs.asyncOutBuf[:0]
 	cs.asyncRun = false
 	cs.asyncClosed.Store(false)
+	cs.asyncDetachUnlocked = false
 	cs.fd = 0
 	connStatePool.Put(cs)
 }

--- a/engine/epoll/conn.go
+++ b/engine/epoll/conn.go
@@ -113,6 +113,16 @@ type connState struct {
 	// deadlocked on its own re-entrant Lock attempt when the middleware
 	// emitted the 101 / SSE headers right after Detach.
 	asyncDetachUnlocked bool
+
+	// asyncDetachPending defers worker-private OnDetach mutations
+	// (detachedCount++ and eventfd allocation + EPOLL_CTL_ADD) to
+	// drainDetachQueue, which runs on the event-loop thread. In
+	// async mode the dispatch goroutine fires OnDetach and cannot
+	// safely mutate l.detachedCount (race with the event-loop's
+	// adaptiveTimeout read) or the eventFD slot (race with the event
+	// loop's epoll_wait set). The flag is set by OnDetach and
+	// cleared by drainDetachQueue once the bookkeeping runs.
+	asyncDetachPending bool
 }
 
 var connStatePool = sync.Pool{
@@ -167,6 +177,7 @@ func releaseConnState(cs *connState) {
 	cs.asyncRun = false
 	cs.asyncClosed.Store(false)
 	cs.asyncDetachUnlocked = false
+	cs.asyncDetachPending = false
 	cs.fd = 0
 	connStatePool.Put(cs)
 }

--- a/engine/epoll/loop.go
+++ b/engine/epoll/loop.go
@@ -917,7 +917,17 @@ func (l *Loop) initProtocol(cs *connState) {
 				mu = &sync.Mutex{}
 				cs.detachMu = mu
 			}
-			l.detachedCount++
+			// Sync mode runs OnDetach on the event-loop thread, so
+			// the worker-owned bookkeeping is safe inline. Async
+			// mode defers to drainDetachQueue via asyncDetachPending
+			// — l.detachedCount races with adaptiveTimeout's read on
+			// the event-loop thread, and the eventfd allocation +
+			// EPOLL_CTL_ADD touches the loop's epoll set.
+			if !l.async {
+				l.detachedCount++
+			} else {
+				cs.asyncDetachPending = true
+			}
 			orig := cs.writeFn
 			guarded := func(data []byte) {
 				mu.Lock()
@@ -976,8 +986,11 @@ func (l *Loop) initProtocol(cs *connState) {
 					_, _ = unix.Write(l.eventFD, val[:])
 				}
 			}
-			// Ensure eventfd is available for wakeup.
-			if l.eventFD < 0 {
+			// Ensure eventfd is available for wakeup. Sync mode is
+			// safe to mutate l.eventFD inline (event-loop thread).
+			// Async mode defers to drainDetachQueue (worker thread)
+			// via asyncDetachPending — see the field's comment.
+			if !l.async && l.eventFD < 0 {
 				efd, err := unix.Eventfd(0, unix.EFD_NONBLOCK|unix.EFD_CLOEXEC)
 				if err == nil {
 					l.eventFD = efd
@@ -1000,6 +1013,22 @@ func (l *Loop) initProtocol(cs *connState) {
 			if l.async && cs.detachMu != nil && !cs.asyncDetachUnlocked {
 				cs.asyncDetachUnlocked = true
 				cs.detachMu.Unlock()
+			}
+			// Async mode: enqueue cs so drainDetachQueue picks up the
+			// deferred bookkeeping (asyncDetachPending). The first
+			// guarded() write will also enqueue+signal, but the
+			// explicit signal here covers the rare case where the
+			// middleware returns without writing.
+			if l.async {
+				l.detachQMu.Lock()
+				l.detachQueue = append(l.detachQueue, cs)
+				l.detachQPending.Store(1)
+				l.detachQMu.Unlock()
+				if l.eventFD >= 0 {
+					var val [8]byte
+					val[0] = 1
+					_, _ = unix.Write(l.eventFD, val[:])
+				}
 			}
 		}
 		cs.h1State.HijackFn = func() (net.Conn, error) {
@@ -1342,6 +1371,27 @@ func (l *Loop) drainDetachQueue() {
 			l.h2Conns = append(l.h2Conns, cs.fd)
 			l.markDirty(cs)
 			continue
+		}
+		// Async-mode Detach finalisation: OnDetach ran on the
+		// dispatch goroutine and cannot touch event-loop-owned state
+		// (l.detachedCount or l.eventFD). It set asyncDetachPending
+		// and enqueued cs so we land here on the event-loop thread
+		// and run those mutations safely. Idempotent — the flag is
+		// cleared before the bookkeeping so a second drainDetachQueue
+		// pass (from the same enqueue burst) is a no-op.
+		if cs.asyncDetachPending {
+			cs.asyncDetachPending = false
+			l.detachedCount++
+			if l.eventFD < 0 {
+				efd, err := unix.Eventfd(0, unix.EFD_NONBLOCK|unix.EFD_CLOEXEC)
+				if err == nil {
+					l.eventFD = efd
+					_ = unix.EpollCtl(l.epollFD, unix.EPOLL_CTL_ADD, efd, &unix.EpollEvent{
+						Events: unix.EPOLLIN | unix.EPOLLET,
+						Fd:     int32(efd),
+					})
+				}
+			}
 		}
 		// Apply any pending pause/resume request from the WS middleware.
 		// EPOLL_CTL_MOD with Events=0 stops EPOLLIN delivery; restoring

--- a/engine/epoll/loop.go
+++ b/engine/epoll/loop.go
@@ -987,6 +987,20 @@ func (l *Loop) initProtocol(cs *connState) {
 					})
 				}
 			}
+			// Async mode (HTTP1): the dispatch goroutine took detachMu
+			// around ProcessH1 so writeBuf access serialises with the
+			// event loop's flushWrites. Now that we've installed
+			// `guarded` (which re-acquires detachMu on every call),
+			// keeping the lock held would deadlock the very next write
+			// — including the middleware-emitted 101 / SSE headers
+			// that immediately follow Detach. Release the lock here
+			// and have the dispatch goroutine observe
+			// asyncDetachUnlocked to skip its symmetric Unlock when
+			// ProcessH1 returns. See celeris#273.
+			if l.async && cs.detachMu != nil && !cs.asyncDetachUnlocked {
+				cs.asyncDetachUnlocked = true
+				cs.detachMu.Unlock()
+			}
 		}
 		cs.h1State.HijackFn = func() (net.Conn, error) {
 			return l.hijackConn(cs.fd)
@@ -1202,6 +1216,41 @@ func (l *Loop) runAsyncHandler(cs *connState) {
 				_, _ = unix.Write(l.eventFD, val[:])
 			}
 			return
+		}
+		// celeris#273: a user handler may have called c.Detach() inside
+		// ProcessH1 (websocket or sse middleware). OnDetach released
+		// detachMu so subsequent guarded writeFn calls don't deadlock.
+		// The dispatch goroutine no longer owns the lock — skip the
+		// inline-flush path (the bytes were already enqueued via
+		// guarded → detachQueue/eventfd, the event loop will flush
+		// them) and skip the symmetric Unlock below.
+		if cs.asyncDetachUnlocked {
+			// ErrHijacked is a valid post-Detach return: the H1 parser
+			// considers a hijacked conn "done with the request". Treat
+			// it like nil here — the middleware now owns the conn.
+			if processErr != nil && !errors.Is(processErr, conn.ErrHijacked) {
+				cs.asyncClosed.Store(true)
+				cs.asyncInMu.Lock()
+				cs.asyncInBuf = cs.asyncInBuf[:0]
+				cs.asyncRun = false
+				cs.asyncInMu.Unlock()
+				l.detachQMu.Lock()
+				l.detachQueue = append(l.detachQueue, cs)
+				l.detachQPending.Store(1)
+				l.detachQMu.Unlock()
+				if l.eventFD >= 0 {
+					var val [8]byte
+					val[0] = 1
+					_, _ = unix.Write(l.eventFD, val[:])
+				}
+				return
+			}
+			// Post-Detach: loop back to wait for more recv bytes (WS
+			// frames delivered via WSDataDelivery, or SSE conn-close
+			// detection). The handler runs in its own goroutine
+			// spawned by the middleware; this dispatch goroutine just
+			// shuttles RX bytes into ProcessH1 → WSDataDelivery.
+			continue
 		}
 		var flushErr error
 		if processErr == nil && (cs.writePos < len(cs.writeBuf) || len(cs.bodyBuf) > 0) {

--- a/engine/iouring/conn.go
+++ b/engine/iouring/conn.go
@@ -131,6 +131,16 @@ type connState struct {
 	// detachMu freshly through the guarded closure — no deadlock, no
 	// race with the worker's flushSend.
 	asyncDetachUnlocked bool
+
+	// asyncDetachPending is set by OnDetach in async mode to defer the
+	// worker-private bookkeeping (detachedCount++, prepareH2Poll arm)
+	// to drainDetachQueue, which runs on the worker thread. The
+	// dispatch goroutine MUST NOT mutate worker-owned state directly —
+	// w.detachedCount races with adaptiveTimeout's read on the worker
+	// thread, and the ring's SQE submission is SINGLE_ISSUER (only the
+	// worker may call GetSQE). Cleared by drainDetachQueue after the
+	// bookkeeping runs, and by releaseConnState on teardown.
+	asyncDetachPending bool
 }
 
 var connStatePool = sync.Pool{
@@ -194,6 +204,7 @@ func releaseConnState(cs *connState) {
 	cs.asyncRun = false
 	cs.asyncClosed.Store(false)
 	cs.asyncDetachUnlocked = false
+	cs.asyncDetachPending = false
 	cs.bodyBuf = nil
 	cs.sendBody = nil
 	cs.fd = 0

--- a/engine/iouring/conn.go
+++ b/engine/iouring/conn.go
@@ -113,6 +113,24 @@ type connState struct {
 	// keeps the conn alive, rather than routing it through the
 	// asyncClosed teardown.
 	asyncH2Promoted atomic.Bool
+
+	// asyncDetachUnlocked is set by OnDetach when it releases detachMu
+	// on behalf of the dispatch goroutine. runAsyncHandler observes it
+	// after ProcessH1 returns and skips the symmetric final Unlock
+	// (otherwise it would unlock an already-released mutex). Cleared by
+	// releaseConnState.
+	//
+	// Background: in async mode the dispatch goroutine takes detachMu
+	// around ProcessH1 so writeBuf access serialises with the worker's
+	// flushSend. After Detach, the engine swaps writeFn to a "guarded"
+	// closure that re-acquires detachMu — which would deadlock if the
+	// dispatch goroutine still holds it. OnDetach therefore releases
+	// the lock early, and this flag prevents runAsyncHandler from
+	// double-unlocking. Post-Detach writes (from the dispatch goroutine
+	// itself or from spawned middleware goroutines like ws/sse) acquire
+	// detachMu freshly through the guarded closure — no deadlock, no
+	// race with the worker's flushSend.
+	asyncDetachUnlocked bool
 }
 
 var connStatePool = sync.Pool{
@@ -175,6 +193,7 @@ func releaseConnState(cs *connState) {
 	cs.asyncOutBuf = cs.asyncOutBuf[:0]
 	cs.asyncRun = false
 	cs.asyncClosed.Store(false)
+	cs.asyncDetachUnlocked = false
 	cs.bodyBuf = nil
 	cs.sendBody = nil
 	cs.fd = 0

--- a/engine/iouring/worker.go
+++ b/engine/iouring/worker.go
@@ -939,6 +939,22 @@ func (w *Worker) initProtocol(cs *connState) {
 				w.prepareH2Poll()
 				w.h2PollArmed = true
 			}
+			// Async mode (HTTP1): the dispatch goroutine took detachMu
+			// around ProcessH1 so writeBuf access serialises with the
+			// worker's flushSend. Now that we've installed `guarded`
+			// (which re-acquires detachMu on every call), keeping the
+			// lock held would deadlock the very next write — including
+			// the middleware-emitted 101 / SSE headers that immediately
+			// follow Detach. Release the lock here and have the
+			// dispatch goroutine observe asyncDetachUnlocked to skip
+			// its symmetric Unlock when ProcessH1 returns. This is
+			// celeris#273 — pre-fix, /ws and /events would TIMEOUT on
+			// iouring + AsyncHandlers because the dispatch goroutine
+			// was deadlocked on its own re-entrant Lock attempt.
+			if w.async && cs.detachMu != nil && !cs.asyncDetachUnlocked {
+				cs.asyncDetachUnlocked = true
+				cs.detachMu.Unlock()
+			}
 		}
 		if !cs.fixedFile {
 			cs.h1State.HijackFn = func() (net.Conn, error) {
@@ -1948,6 +1964,42 @@ func (w *Worker) runAsyncHandler(cs *connState) {
 				_, _ = unix.Write(w.h2EventFD, val[:])
 			}
 			return
+		}
+		// celeris#273: a user handler may have called c.Detach() inside
+		// ProcessH1 (websocket or sse middleware). OnDetach released
+		// detachMu so subsequent guarded writeFn calls don't deadlock.
+		// The dispatch goroutine no longer owns the lock — skip the
+		// direct-write path (the bytes were already enqueued via
+		// guarded → detachQueue/eventfd, the worker will flushSend
+		// them) and skip the symmetric Unlock below.
+		if cs.asyncDetachUnlocked {
+			// ErrHijacked is a valid post-Detach return: the H1 parser
+			// considers a hijacked conn "done with the request". Treat
+			// it like nil here — the middleware now owns the conn and
+			// is responsible for its lifetime via the done() callback.
+			if processErr != nil && !errors.Is(processErr, conn.ErrHijacked) {
+				cs.asyncClosed.Store(true)
+				cs.asyncInMu.Lock()
+				cs.asyncInBuf = cs.asyncInBuf[:0]
+				cs.asyncRun = false
+				cs.asyncInMu.Unlock()
+				w.detachQMu.Lock()
+				w.detachQueue = append(w.detachQueue, cs)
+				w.detachQPending.Store(1)
+				w.detachQMu.Unlock()
+				if w.h2EventFD >= 0 {
+					var val [8]byte
+					val[0] = 1
+					_, _ = unix.Write(w.h2EventFD, val[:])
+				}
+				return
+			}
+			// Post-Detach: loop back to wait for more recv bytes (WS
+			// frames delivered via WSDataDelivery, or SSE conn-close
+			// detection). The handler runs in its own goroutine
+			// spawned by the middleware; this dispatch goroutine just
+			// shuttles RX bytes into ProcessH1 → WSDataDelivery.
+			continue
 		}
 		// Direct-write fast path: on the async-handler goroutine, call
 		// unix.Write(fd, writeBuf) inline instead of bouncing through

--- a/engine/iouring/worker.go
+++ b/engine/iouring/worker.go
@@ -873,7 +873,20 @@ func (w *Worker) initProtocol(cs *connState) {
 				mu = &sync.Mutex{}
 				cs.detachMu = mu
 			}
-			w.detachedCount++
+			// Sync mode: OnDetach runs on the worker thread, so the
+			// worker-owned bookkeeping is safe to mutate here.
+			// Async mode: OnDetach runs on the per-conn dispatch
+			// goroutine — w.detachedCount races with the worker
+			// thread's adaptiveTimeout read and any ring SQE
+			// submission violates SINGLE_ISSUER. Defer both to
+			// drainDetachQueue via asyncDetachPending so the worker
+			// owns the mutation. The first guarded() write below
+			// enqueues+signals, so drainDetachQueue fires promptly.
+			if !w.async {
+				w.detachedCount++
+			} else {
+				cs.asyncDetachPending = true
+			}
 			orig := cs.writeFn
 			wakeupFD := w.h2EventFD
 			guarded := func(data []byte) {
@@ -935,7 +948,12 @@ func (w *Worker) initProtocol(cs *connState) {
 				}
 			}
 			// Ensure eventfd poll is armed so the worker wakes up.
-			if !w.h2PollArmed && w.h2EventFD >= 0 {
+			// Sync mode runs OnDetach on the worker thread, so this
+			// SQE submission is safe. Async mode defers to
+			// drainDetachQueue (worker-thread) via asyncDetachPending
+			// — see the SINGLE_ISSUER note on the asyncDetachPending
+			// field.
+			if !w.async && !w.h2PollArmed && w.h2EventFD >= 0 {
 				w.prepareH2Poll()
 				w.h2PollArmed = true
 			}
@@ -954,6 +972,24 @@ func (w *Worker) initProtocol(cs *connState) {
 			if w.async && cs.detachMu != nil && !cs.asyncDetachUnlocked {
 				cs.asyncDetachUnlocked = true
 				cs.detachMu.Unlock()
+			}
+			// Async mode: enqueue cs so drainDetachQueue picks up the
+			// deferred bookkeeping (asyncDetachPending). The first
+			// guarded() write will also enqueue+signal, but the
+			// explicit signal here covers the rare case where the
+			// middleware returns without writing (e.g. a 4xx Detach
+			// rejection path). Idempotent — drainDetachQueue
+			// clears asyncDetachPending after running it.
+			if w.async {
+				w.detachQMu.Lock()
+				w.detachQueue = append(w.detachQueue, cs)
+				w.detachQPending.Store(1)
+				w.detachQMu.Unlock()
+				if wakeupFD >= 0 {
+					var val [8]byte
+					val[0] = 1
+					_, _ = unix.Write(wakeupFD, val[:])
+				}
 			}
 		}
 		if !cs.fixedFile {
@@ -2232,6 +2268,21 @@ func (w *Worker) drainDetachQueue() {
 			w.h2Conns = append(w.h2Conns, cs.fd)
 			w.markDirty(cs)
 			continue
+		}
+		// Async-mode Detach finalisation: OnDetach ran on the
+		// dispatch goroutine and cannot touch worker-owned state
+		// (w.detachedCount or the ring). It set asyncDetachPending
+		// and enqueued cs so we land here on the worker thread and
+		// run those mutations safely. Idempotent — the flag is
+		// cleared before the bookkeeping so a second drainDetachQueue
+		// pass (from the same enqueue burst) is a no-op.
+		if cs.asyncDetachPending {
+			cs.asyncDetachPending = false
+			w.detachedCount++
+			if !w.h2PollArmed && w.h2EventFD >= 0 {
+				w.prepareH2Poll()
+				w.h2PollArmed = true
+			}
 		}
 		// Apply pending pause/resume request from the WS middleware.
 		// Pause: cancel any in-flight RECV (multishot or single-shot)

--- a/middleware/sse/sse.go
+++ b/middleware/sse/sse.go
@@ -365,155 +365,192 @@ func New(config ...Config) celeris.HandlerFunc {
 
 		done := c.Detach()
 
-		if err := sw.WriteHeader(200, sseHeaders); err != nil {
-			cancel()
-			releaseClient(client)
-			done()
-			return err
-		}
-
+		// Engine asymmetry (celeris#273):
+		//
+		//   - native engines (epoll, io_uring): the handler runs on the
+		//     event-loop thread (sync) or the per-conn dispatch
+		//     goroutine (AsyncHandlers=true). A handler that blocks —
+		//     and every SSE handler blocks until the client disconnects
+		//     — blocks the engine from processing this conn's writes,
+		//     so the response headers and every Send sit in the engine
+		//     buffer forever. The middleware therefore spawns its own
+		//     goroutine to drive the stream and returns from the
+		//     request handler immediately, freeing the engine thread.
+		//   - std engine: the handler runs in net/http's per-request
+		//     goroutine. Returning from the request handler signals
+		//     "response complete" and net/http closes the conn. The
+		//     middleware must run the stream inline.
+		//
+		// Pre-v1.4.4 the middleware always ran inline, which manifested
+		// as the SSE row of celeris#273's repro matrix
+		// (iouring|epoll × any AsyncHandlers → TIMEOUT on /events).
 		// heartbeatDone is closed by the heartbeat goroutine on exit so the
 		// defer can wait for it before returning the Client to the pool.
 		// Without this, the goroutine could read client.closed after a
 		// future test reused the pooled Client (data race).
 		var heartbeatDone chan struct{}
 
-		defer func() {
-			// Tear-down ordering — load-bearing:
-			//
-			//   1. queueClosed.Store(true) — fast-path Send check.
-			//   2. cancel() — wakes any Send parked in
-			//      ClientPolicyBlock's select on c.ctx.Done(). MUST
-			//      precede close(c.queue): a producer that observed
-			//      queueClosed==false in the fast path can be in the
-			//      select at the moment we close the queue, and would
-			//      panic on send-to-closed-chan if ctx was not
-			//      already done. With cancel ahead of close, the
-			//      ctx.Done() arm of the select wins instead.
-			//   3. close(c.queue) — drain goroutine ranges to
-			//      completion, flushing in-queue events.
-			//   4. <-c.drainDone — join the drain.
-			//   5. client.Close() — idempotent; cancel already fired,
-			//      so this is just the sw.Close + closed=true bookkeeping.
-			if client.queue != nil {
-				client.queueClosed.Store(true)
+		// writeErr captures the first error from sw.WriteHeader /
+		// sw.Write / sw.Flush during the bootstrap (pre-handler) phase
+		// so the inline std-engine path can surface it as the request
+		// handler's return value — preserves the v1.4.3 contract that
+		// TestWriteErrorOnHeaders pins. The native-engine goroutine
+		// path returns nil from the request handler before bootstrap
+		// runs, so it discards writeErr (the engine has already
+		// committed to "this conn is detached and the stream owns it").
+		var writeErr error
+
+		runStream := func() {
+			defer func() {
+				// Tear-down ordering — load-bearing:
+				//
+				//   1. queueClosed.Store(true) — fast-path Send check.
+				//   2. cancel() — wakes any Send parked in
+				//      ClientPolicyBlock's select on c.ctx.Done(). MUST
+				//      precede close(c.queue): a producer that observed
+				//      queueClosed==false in the fast path can be in the
+				//      select at the moment we close the queue, and would
+				//      panic on send-to-closed-chan if ctx was not
+				//      already done. With cancel ahead of close, the
+				//      ctx.Done() arm of the select wins instead.
+				//   3. close(c.queue) — drain goroutine ranges to
+				//      completion, flushing in-queue events.
+				//   4. <-c.drainDone — join the drain.
+				//   5. client.Close() — idempotent; cancel already fired,
+				//      so this is just the sw.Close + closed=true bookkeeping.
+				if client.queue != nil {
+					client.queueClosed.Store(true)
+					cancel()
+					close(client.queue)
+				}
+				if client.drainDone != nil {
+					<-client.drainDone
+				}
+				_ = client.Close()
+				if heartbeatDone != nil {
+					<-heartbeatDone
+				}
+				if onDisconnect != nil {
+					onDisconnect(c, client)
+				}
+				releaseClient(client)
+				done()
+			}()
+
+			if err := sw.WriteHeader(200, sseHeaders); err != nil {
+				writeErr = err
 				cancel()
-				close(client.queue)
+				return
 			}
-			if client.drainDone != nil {
-				<-client.drainDone
-			}
-			_ = client.Close()
-			if heartbeatDone != nil {
-				<-heartbeatDone
-			}
-			if onDisconnect != nil {
-				onDisconnect(c, client)
-			}
-			releaseClient(client)
-			done()
-		}()
 
-		// Flush the SSE response headers immediately so EventSource
-		// clients can begin reading. Without this, the std engine
-		// buffers headers until the first body byte — fine for
-		// handlers that Send right away, but a deadlock for broker
-		// patterns that Subscribe and wait for the next Publish.
-		// The retry line piggybacks on the same flush when set.
-		client.mu.Lock()
-		var err error
-		if len(retryLine) > 0 {
-			_, err = sw.Write(retryLine)
-		}
-		if err == nil {
-			err = sw.Flush()
-		}
-		client.mu.Unlock()
-		if err != nil {
-			return nil
-		}
-
-		// Bind the replay store to the client BEFORE the drain goroutine
-		// starts so an event enqueued the instant the handler runs hits
-		// Append on its way to the wire.
-		client.replayStore = cfg.ReplayStore
-
-		// Replay missed events from the previous session, if any.
-		// ErrLastIDUnknown is the documented "fresh start" signal:
-		// silently fall through and let Handler decide; the user's
-		// Handler can still consult client.LastEventID() to react to
-		// the unknown cursor itself.
-		//
-		// Holding client.mu across the entire replay loop is
-		// load-bearing for Last-Event-ID monotonicity: a concurrent
-		// Send (e.g. via a Broker.Publish that fires before the
-		// handler reaches its Subscribe) would otherwise interleave
-		// a newer event mid-replay; if the client disconnects mid-
-		// replay it would record the newer event's ID and skip the
-		// still-pending replay tail on next reconnect.
-		if cfg.ReplayStore != nil && lastEventID != "" {
-			missed, err := cfg.ReplayStore.Since(ctx, lastEventID)
-			if err != nil && !errors.Is(err, ErrLastIDUnknown) {
-				return nil
-			}
+			// Flush the SSE response headers immediately so EventSource
+			// clients can begin reading. Without this, the std engine
+			// buffers headers until the first body byte — fine for
+			// handlers that Send right away, but a deadlock for broker
+			// patterns that Subscribe and wait for the next Publish.
+			// The retry line piggybacks on the same flush when set.
 			client.mu.Lock()
-			for i := range missed {
-				client.buf = formatEvent(client.buf, &missed[i])
-				_, werr := sw.Write(client.buf)
-				if werr == nil {
-					werr = sw.Flush()
-				}
-				if werr != nil {
-					client.mu.Unlock()
-					return nil
-				}
+			var err error
+			if len(retryLine) > 0 {
+				_, err = sw.Write(retryLine)
+			}
+			if err == nil {
+				err = sw.Flush()
 			}
 			client.mu.Unlock()
-		}
+			if err != nil {
+				writeErr = err
+				return
+			}
 
-		// Start per-client drain goroutine when queued-send mode is active.
-		// Stays in lockstep with the handler lifecycle: started after the
-		// retry line so the channel cannot leak events written before the
-		// client even saw the response, joined in the defer above.
-		if cfg.MaxQueueDepth > 0 {
-			client.queue = make(chan Event, cfg.MaxQueueDepth)
-			client.drainDone = make(chan struct{})
-			client.onSlowClient = cfg.OnSlowClient
-			go client.drain()
-		}
+			// Bind the replay store to the client BEFORE the drain goroutine
+			// starts so an event enqueued the instant the handler runs hits
+			// Append on its way to the wire.
+			client.replayStore = cfg.ReplayStore
 
-		// Start heartbeat goroutine.
-		if heartbeatInterval > 0 {
-			heartbeatDone = make(chan struct{})
-			go func() {
-				defer close(heartbeatDone)
-				ticker := time.NewTicker(heartbeatInterval)
-				defer ticker.Stop()
-				for {
-					select {
-					case <-ctx.Done():
-						return
-					case <-ticker.C:
-						client.mu.Lock()
-						if client.closed {
-							client.mu.Unlock()
-							return
-						}
-						_, err := sw.Write(heartbeatBytes)
-						if err == nil {
-							err = sw.Flush()
-						}
+			// Replay missed events from the previous session, if any.
+			// ErrLastIDUnknown is the documented "fresh start" signal:
+			// silently fall through and let Handler decide; the user's
+			// Handler can still consult client.LastEventID() to react to
+			// the unknown cursor itself.
+			//
+			// Holding client.mu across the entire replay loop is
+			// load-bearing for Last-Event-ID monotonicity: a concurrent
+			// Send (e.g. via a Broker.Publish that fires before the
+			// handler reaches its Subscribe) would otherwise interleave
+			// a newer event mid-replay; if the client disconnects mid-
+			// replay it would record the newer event's ID and skip the
+			// still-pending replay tail on next reconnect.
+			if cfg.ReplayStore != nil && lastEventID != "" {
+				missed, err := cfg.ReplayStore.Since(ctx, lastEventID)
+				if err != nil && !errors.Is(err, ErrLastIDUnknown) {
+					return
+				}
+				client.mu.Lock()
+				for i := range missed {
+					client.buf = formatEvent(client.buf, &missed[i])
+					_, werr := sw.Write(client.buf)
+					if werr == nil {
+						werr = sw.Flush()
+					}
+					if werr != nil {
 						client.mu.Unlock()
-						if err != nil {
-							cancel()
-							return
-						}
+						return
 					}
 				}
-			}()
+				client.mu.Unlock()
+			}
+
+			// Start per-client drain goroutine when queued-send mode is active.
+			// Stays in lockstep with the handler lifecycle: started after the
+			// retry line so the channel cannot leak events written before the
+			// client even saw the response, joined in the defer above.
+			if cfg.MaxQueueDepth > 0 {
+				client.queue = make(chan Event, cfg.MaxQueueDepth)
+				client.drainDone = make(chan struct{})
+				client.onSlowClient = cfg.OnSlowClient
+				go client.drain()
+			}
+
+			// Start heartbeat goroutine.
+			if heartbeatInterval > 0 {
+				heartbeatDone = make(chan struct{})
+				go func() {
+					defer close(heartbeatDone)
+					ticker := time.NewTicker(heartbeatInterval)
+					defer ticker.Stop()
+					for {
+						select {
+						case <-ctx.Done():
+							return
+						case <-ticker.C:
+							client.mu.Lock()
+							if client.closed {
+								client.mu.Unlock()
+								return
+							}
+							_, err := sw.Write(heartbeatBytes)
+							if err == nil {
+								err = sw.Flush()
+							}
+							client.mu.Unlock()
+							if err != nil {
+								cancel()
+								return
+							}
+						}
+					}
+				}()
+			}
+
+			handler(client)
 		}
 
-		handler(client)
-		return nil
+		if c.EngineSupportsAsyncDetach() {
+			go runStream()
+			return nil
+		}
+		runStream()
+		return writeErr
 	}
 }

--- a/middleware/sse/sse_engine_linux_test.go
+++ b/middleware/sse/sse_engine_linux_test.go
@@ -1,0 +1,140 @@
+//go:build linux
+
+package sse_test
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/goceleris/celeris"
+	"github.com/goceleris/celeris/middleware/sse"
+)
+
+// TestSSEOnNativeEngines is a regression pin for celeris#273. Before
+// v1.4.4, an SSE handler running under iouring or epoll would hang
+// because the user handler ran inline on the worker thread (or the
+// async dispatch goroutine), preventing the engine from flushing the
+// chunked-encoded events. Async-mode iouring/epoll additionally
+// deadlocked the dispatch goroutine on the post-Detach guarded write
+// lock.
+//
+// The test boots celeris with each native engine + each AsyncHandlers
+// setting, drives /events for 1 s, and expects at least two ticks to
+// reach the client. A timeout-and-no-events outcome is the bug.
+func TestSSEOnNativeEngines(t *testing.T) {
+	cases := []struct {
+		name   string
+		engine celeris.EngineType
+		async  bool
+	}{
+		{"iouring/async", celeris.IOUring, true},
+		{"iouring/sync", celeris.IOUring, false},
+		{"epoll/async", celeris.Epoll, true},
+		{"epoll/sync", celeris.Epoll, false},
+		{"std/async", celeris.Std, true},
+		{"std/sync", celeris.Std, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ln, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			addr := ln.Addr().String()
+
+			srv := celeris.New(celeris.Config{
+				Engine:        tc.engine,
+				AsyncHandlers: tc.async,
+			})
+			srv.GET("/events", sse.New(sse.Config{
+				HeartbeatInterval: -1,
+				Handler: func(client *sse.Client) {
+					tick := time.NewTicker(50 * time.Millisecond)
+					defer tick.Stop()
+					ctx := client.Context()
+					for n := 0; n < 5; {
+						select {
+						case <-ctx.Done():
+							return
+						case <-tick.C:
+							n++
+							if err := client.Send(sse.Event{
+								Event: "tick",
+								Data:  fmt.Sprintf("%d", n),
+							}); err != nil {
+								return
+							}
+						}
+					}
+				},
+			}))
+			var startErr atomic.Pointer[error]
+			startCtx, startCancel := context.WithCancel(context.Background())
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				if e := srv.StartWithListenerAndContext(startCtx, ln); e != nil {
+					startErr.Store(&e)
+				}
+			}()
+			// iouring/epoll rebind via SO_REUSEPORT to acquire workers
+			// on their own listening FDs — they close the listener we
+			// passed in and re-bind to the same port. The transient
+			// kernel-side flip can briefly accept and immediately RST
+			// a probe connection during the window. Sleep half a
+			// second to let the engine settle before driving the
+			// real test. Mirrors the wait in cmd/runner and the
+			// repro binary that proves the fix on cluster hardware.
+			time.Sleep(500 * time.Millisecond)
+			if p := startErr.Load(); p != nil {
+				t.Fatalf("server start: %v", *p)
+			}
+			defer func() {
+				startCancel()
+				select {
+				case <-done:
+				case <-time.After(3 * time.Second):
+					t.Log("server goroutine did not exit within 3s")
+				}
+			}()
+
+			// Open the SSE stream with a 2 s read deadline; require at
+			// least two `event: tick` lines.
+			conn, err := net.DialTimeout("tcp", addr, 1*time.Second)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer conn.Close()
+			_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+			req := "GET /events HTTP/1.1\r\n" +
+				"Host: " + addr + "\r\n" +
+				"Accept: text/event-stream\r\n" +
+				"Connection: keep-alive\r\n" +
+				"\r\n"
+			if _, err := conn.Write([]byte(req)); err != nil {
+				t.Fatal(err)
+			}
+			br := bufio.NewReader(conn)
+			events := 0
+			for events < 2 {
+				line, err := br.ReadString('\n')
+				if err != nil {
+					t.Fatalf("read after %d events: %v", events, err)
+				}
+				if strings.HasPrefix(line, "event: tick") {
+					events++
+				}
+			}
+			if events < 2 {
+				t.Fatalf("only %d SSE events received; engine hung the stream", events)
+			}
+		})
+	}
+}
+

--- a/middleware/sse/sse_engine_linux_test.go
+++ b/middleware/sse/sse_engine_linux_test.go
@@ -93,6 +93,15 @@ func TestSSEOnNativeEngines(t *testing.T) {
 			// repro binary that proves the fix on cluster hardware.
 			time.Sleep(500 * time.Millisecond)
 			if p := startErr.Load(); p != nil {
+				// Docker / minimal-kernel CI runners may lack io_uring
+				// support (e.g. seccomp filtering, kernel <5.1 emulation).
+				// Skip rather than fail — the test exercises a
+				// kernel-feature-gated path and the failure mode is
+				// "engine unavailable", not a celeris bug.
+				msg := (*p).Error()
+				if strings.Contains(msg, "io_uring") || strings.Contains(msg, "not available") {
+					t.Skipf("engine unavailable on this runner: %v", *p)
+				}
 				t.Fatalf("server start: %v", *p)
 			}
 			defer func() {
@@ -110,7 +119,7 @@ func TestSSEOnNativeEngines(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer conn.Close()
+			defer func() { _ = conn.Close() }()
 			_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
 			req := "GET /events HTTP/1.1\r\n" +
 				"Host: " + addr + "\r\n" +
@@ -137,4 +146,3 @@ func TestSSEOnNativeEngines(t *testing.T) {
 		})
 	}
 }
-

--- a/middleware/websocket/websocket_engine_linux_test.go
+++ b/middleware/websocket/websocket_engine_linux_test.go
@@ -77,6 +77,14 @@ func TestWebSocketUpgradeOnNativeEngines(t *testing.T) {
 			// to settle. See sse_engine_linux_test.go for context.
 			time.Sleep(500 * time.Millisecond)
 			if p := startErr.Load(); p != nil {
+				// Docker / minimal-kernel CI runners may lack io_uring
+				// support. Skip rather than fail — the test exercises a
+				// kernel-feature-gated path and the failure mode is
+				// "engine unavailable", not a celeris bug.
+				msg := (*p).Error()
+				if strings.Contains(msg, "io_uring") || strings.Contains(msg, "not available") {
+					t.Skipf("engine unavailable on this runner: %v", *p)
+				}
 				t.Fatalf("server start: %v", *p)
 			}
 			defer func() {
@@ -92,7 +100,7 @@ func TestWebSocketUpgradeOnNativeEngines(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer conn.Close()
+			defer func() { _ = conn.Close() }()
 			_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
 			req := "GET /ws HTTP/1.1\r\n" +
 				"Host: " + addr + "\r\n" +
@@ -115,4 +123,3 @@ func TestWebSocketUpgradeOnNativeEngines(t *testing.T) {
 		})
 	}
 }
-

--- a/middleware/websocket/websocket_engine_linux_test.go
+++ b/middleware/websocket/websocket_engine_linux_test.go
@@ -1,0 +1,118 @@
+//go:build linux
+
+package websocket_test
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/goceleris/celeris"
+	"github.com/goceleris/celeris/middleware/websocket"
+)
+
+// TestWebSocketUpgradeOnNativeEngines is a regression pin for
+// celeris#273. Before v1.4.4, async-mode iouring and epoll would
+// deadlock the dispatch goroutine on the post-Detach guarded write
+// lock when the websocket middleware tried to emit the 101 Switching
+// Protocols response — the lock was held by the same goroutine that
+// just installed the guarded writeFn.
+//
+// The test exercises the upgrade path on every (engine, async) pair
+// and asserts the server replies "HTTP/1.1 101 Switching Protocols"
+// within a 2 s read deadline.
+func TestWebSocketUpgradeOnNativeEngines(t *testing.T) {
+	cases := []struct {
+		name   string
+		engine celeris.EngineType
+		async  bool
+	}{
+		{"iouring/async", celeris.IOUring, true},
+		{"iouring/sync", celeris.IOUring, false},
+		{"epoll/async", celeris.Epoll, true},
+		{"epoll/sync", celeris.Epoll, false},
+		{"std/async", celeris.Std, true},
+		{"std/sync", celeris.Std, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ln, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			addr := ln.Addr().String()
+
+			srv := celeris.New(celeris.Config{
+				Engine:        tc.engine,
+				AsyncHandlers: tc.async,
+			})
+			srv.GET("/ws", websocket.New(websocket.Config{
+				CheckOrigin: func(c *celeris.Context) bool { return true },
+				Handler: func(c *websocket.Conn) {
+					for {
+						mt, msg, err := c.ReadMessage()
+						if err != nil {
+							return
+						}
+						if err := c.WriteMessage(mt, msg); err != nil {
+							return
+						}
+					}
+				},
+			}))
+			var startErr atomic.Pointer[error]
+			startCtx, startCancel := context.WithCancel(context.Background())
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				if e := srv.StartWithListenerAndContext(startCtx, ln); e != nil {
+					startErr.Store(&e)
+				}
+			}()
+			// iouring/epoll rebind via SO_REUSEPORT. Give them time
+			// to settle. See sse_engine_linux_test.go for context.
+			time.Sleep(500 * time.Millisecond)
+			if p := startErr.Load(); p != nil {
+				t.Fatalf("server start: %v", *p)
+			}
+			defer func() {
+				startCancel()
+				select {
+				case <-done:
+				case <-time.After(3 * time.Second):
+					t.Log("server goroutine did not exit within 3s")
+				}
+			}()
+
+			conn, err := net.DialTimeout("tcp", addr, 1*time.Second)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer conn.Close()
+			_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+			req := "GET /ws HTTP/1.1\r\n" +
+				"Host: " + addr + "\r\n" +
+				"Connection: Upgrade\r\n" +
+				"Upgrade: websocket\r\n" +
+				"Sec-WebSocket-Version: 13\r\n" +
+				"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+				"\r\n"
+			if _, err := conn.Write([]byte(req)); err != nil {
+				t.Fatal(err)
+			}
+			br := bufio.NewReader(conn)
+			line, err := br.ReadString('\n')
+			if err != nil {
+				t.Fatalf("read first line: %v", err)
+			}
+			if !strings.HasPrefix(line, "HTTP/1.1 101") {
+				t.Fatalf("expected 101 Switching Protocols, got %q", strings.TrimSpace(line))
+			}
+		})
+	}
+}
+


### PR DESCRIPTION
## Summary

Two distinct bugs surfaced by the goceleris/probatorium#103 12-day
cluster soak made WebSocket and Server-Sent Events unusable on every
native-engine configuration the production deployment uses
(iouring/epoll × AsyncHandlers=true/false → 4 out of 4 native cells
hung).

### Bug 1 — async dispatch deadlocks on the post-Detach guarded write

In async mode the per-conn dispatch goroutine runs ProcessH1 under
`cs.detachMu` so writeBuf access serialises with the engine's
flushSend. When the user handler calls `c.Detach()` (ws/sse
middleware), the engine's `OnDetach` hook swaps `writeFn` for a
`guarded` closure that re-acquires `cs.detachMu` on every call. The
101 / SSE headers the middleware emits immediately after Detach
therefore deadlocked the dispatch goroutine on its own re-entrant
Lock — no bytes ever reached the wire.

**Fix:** `OnDetach` releases `cs.detachMu` on behalf of the dispatch
goroutine in async mode and sets `cs.asyncDetachUnlocked` so
`runAsyncHandler` skips the symmetric Unlock when ProcessH1 returns.
Post-Detach writes acquire detachMu freshly through the guarded
closure. `ErrHijacked` is treated as a clean post-Detach return
rather than a fatal teardown signal in the same path.

Applied symmetrically in `engine/iouring/worker.go` and
`engine/epoll/loop.go`.

### Bug 2 — SSE handler blocks the worker thread

The `sse` middleware ran `handler(client)` inline. On native engines
that runs on the worker thread (sync) or the per-conn dispatch
goroutine (async). An SSE handler that blocks until the client
disconnects blocks the engine from processing this conn's writes —
heartbeats, replay events, and `Send` calls all silently accumulated
in `writeBuf` and never reached the wire.

**Fix:** the middleware now spawns the user handler in its own
goroutine on engines that wired an `OnDetach` hook and returns
nil from the request handler immediately. The `std` engine still
runs inline (returning would let net/http close the conn underneath
the streaming goroutine).

Engine detection is exposed via the new
`Context.EngineSupportsAsyncDetach()` helper.

## Repro matrix (from celeris#273)

| engine  | AsyncHandlers | /ping | /ws (pre→post) | /events (pre→post) |
|---|---|---|---|---|
| iouring | true  | 200 | **TIMEOUT → 101** | **TIMEOUT → ticks** |
| iouring | false | 200 | **TIMEOUT → 101** | **TIMEOUT → ticks** |
| epoll   | true  | 200 | **TIMEOUT → 101** | **TIMEOUT → ticks** |
| epoll   | false | 200 | **TIMEOUT → 101** | **TIMEOUT → ticks** |
| std     | true  | 200 | 101 | 200 |
| std     | false | 200 | 101 | 200 |

Verified end-to-end on the probatorium cluster (msa2-server, Linux
7.0.0, io_uring tier=high, kernel-mandated 1-worker MEMLOCK).

## Test plan

- [x] New `middleware/sse/sse_engine_linux_test.go` pins all six SSE
      cells — PASS on cluster, 4.16 s.
- [x] New `middleware/websocket/websocket_engine_linux_test.go` pins
      all six WS cells — PASS on cluster, 3.01 s.
- [x] Existing `middleware/sse/...` and `middleware/websocket/...`
      unit tests on std engine still PASS locally
      (`go test -race -count=1`).
- [x] Cross-compile `GOOS=linux GOARCH=amd64 go build ./...` clean.
- [x] Full `./engine/iouring` and `./engine/epoll` suites still PASS
      on cluster.
- [x] Repro binary from celeris#273 issue body shows the full matrix
      flipping to OK after this PR.

## Compatibility

- New `Context.EngineSupportsAsyncDetach()` is additive. Existing
  middleware that does not call `Detach` is unaffected.
- SSE behaviour on the std engine is unchanged (inline handler, same
  goroutine semantics net/http provides).
- The `TestWriteErrorOnHeaders` contract (write errors propagate to
  the request handler's return value) is preserved on the std engine
  via the `writeErr` capture path.

## Issues closed on merge

- Closes #273