### PR TITLE
chore(release): bump celeris pin v1.4.2 → v1.4.4 in middleware sub-modules

### DIFF
--- a/middleware/compress/go.mod
+++ b/middleware/compress/go.mod
@@ -4,7 +4,7 @@ go 1.26.3
 
 require (
 	github.com/andybalholm/brotli v1.2.1
-	github.com/goceleris/celeris v1.4.2
+	github.com/goceleris/celeris v1.4.4
 	github.com/klauspost/compress v1.18.6
 )
 

--- a/middleware/metrics/go.mod
+++ b/middleware/metrics/go.mod
@@ -3,7 +3,7 @@ module github.com/goceleris/celeris/middleware/metrics
 go 1.26.3
 
 require (
-	github.com/goceleris/celeris v1.4.2
+	github.com/goceleris/celeris v1.4.4
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.5

--- a/middleware/otel/go.mod
+++ b/middleware/otel/go.mod
@@ -3,7 +3,7 @@ module github.com/goceleris/celeris/middleware/otel
 go 1.26.3
 
 require (
-	github.com/goceleris/celeris v1.4.2
+	github.com/goceleris/celeris v1.4.4
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0

--- a/middleware/protobuf/go.mod
+++ b/middleware/protobuf/go.mod
@@ -3,7 +3,7 @@ module github.com/goceleris/celeris/middleware/protobuf
 go 1.26.3
 
 require (
-	github.com/goceleris/celeris v1.4.2
+	github.com/goceleris/celeris v1.4.4
 	google.golang.org/protobuf v1.36.11
 )
 


### PR DESCRIPTION
Post-v1.4.4 release follow-up. Bumps the four middleware sub-modules
(\`middleware/compress\`, \`middleware/metrics\`, \`middleware/otel\`,
\`middleware/protobuf\`) so their go.mods reference the freshly-tagged
celeris v1.4.4 on the Go proxy. Same shape as #266 did for v1.4.2.

The \`replace github.com/goceleris/celeris => ../../\` directive in
each sub-module's go.mod keeps the working-tree build self-contained;
the pin change only affects what consumers see when they import
\`middleware/<name>/v1.4.4\`.

After merge, the four sub-module tags (\`middleware/compress/v1.4.4\`
through \`middleware/protobuf/v1.4.4\`) get created so the Go proxy can
serve them.

No code change.