### PR TITLE
docs: add probatorium nightly + weekend tier badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
 # celeris
 
 [![CI](https://github.com/goceleris/celeris/actions/workflows/ci.yml/badge.svg)](https://github.com/goceleris/celeris/actions/workflows/ci.yml)
+[![Probatorium · Nightly](https://github.com/goceleris/probatorium/actions/workflows/matrix-nightly-tier.yml/badge.svg?branch=main&event=schedule)](https://github.com/goceleris/probatorium/actions/workflows/matrix-nightly-tier.yml?query=event%3Aschedule+branch%3Amain)
+[![Probatorium · Weekend](https://github.com/goceleris/probatorium/actions/workflows/matrix-weekend-tier.yml/badge.svg?branch=main&event=schedule)](https://github.com/goceleris/probatorium/actions/workflows/matrix-weekend-tier.yml?query=event%3Aschedule+branch%3Amain)
 [![Go Reference](https://pkg.go.dev/badge/github.com/goceleris/celeris.svg)](https://pkg.go.dev/github.com/goceleris/celeris)
 [![Go Report Card](https://goreportcard.com/badge/github.com/goceleris/celeris)](https://goreportcard.com/report/github.com/goceleris/celeris)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+
+> The two **Probatorium** badges above are the integration-test signal for celeris: they reflect the most recent
+> probatorium full-matrix run (refapp × engine × arch) against this repo's current `main`. Green means no HIGH-severity
+> invariant violations, no cross-engine / cross-arch divergence. Nightly = 1h budget, every day at 02:00 UTC.
+> Weekend = 24h soak, Sundays 02:00 UTC. See [goceleris/probatorium](https://github.com/goceleris/probatorium) for the harness.
 
 Ultra-low latency Go HTTP engine with a protocol-aware dual-architecture (io_uring & epoll) designed for high-throughput infrastructure and zero-allocation microservices. It provides a familiar route-group and middleware API similar to Gin and Echo, so teams can adopt it without learning a new programming model.
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,6 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/goceleris/celeris)](https://goreportcard.com/report/github.com/goceleris/celeris)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
-> The two **Probatorium** badges above are the integration-test signal for celeris: they reflect the most recent
-> probatorium full-matrix run (refapp × engine × arch) against this repo's current `main`. Green means no HIGH-severity
-> invariant violations, no cross-engine / cross-arch divergence. Nightly = 1h budget, every day at 02:00 UTC.
-> Weekend = 24h soak, Sundays 02:00 UTC. See [goceleris/probatorium](https://github.com/goceleris/probatorium) for the harness.
-
 Ultra-low latency Go HTTP engine with a protocol-aware dual-architecture (io_uring & epoll) designed for high-throughput infrastructure and zero-allocation microservices. It provides a familiar route-group and middleware API similar to Gin and Echo, so teams can adopt it without learning a new programming model.
 
 ## Highlights


### PR DESCRIPTION
Adds two badges to the README header that surface the integration-test
status from [goceleris/probatorium](https://github.com/goceleris/probatorium):

- **Probatorium · Nightly** — 1h matrix run (refapp × engine × arch),
  daily 02:00 UTC.
- **Probatorium · Weekend** — 24h matrix soak, Sundays 02:00 UTC.

Green means the most recent run found no HIGH-severity invariant
violations + no cross-engine / cross-arch divergence against celeris's
current \`main\`. The badges complement the existing in-repo CI badge
(which only covers unit tests / lint / vulnerability scan); probatorium
exercises the full middleware × driver × engine surface in matrix mode.

No code change.