### PR TITLE
docs(badges): rename probatorium tier badges + drop event=schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # celeris
 
 [![CI](https://github.com/goceleris/celeris/actions/workflows/ci.yml/badge.svg)](https://github.com/goceleris/celeris/actions/workflows/ci.yml)
-[![Probatorium · Nightly](https://github.com/goceleris/probatorium/actions/workflows/matrix-nightly-tier.yml/badge.svg?branch=main&event=schedule)](https://github.com/goceleris/probatorium/actions/workflows/matrix-nightly-tier.yml?query=event%3Aschedule+branch%3Amain)
-[![Probatorium · Weekend](https://github.com/goceleris/probatorium/actions/workflows/matrix-weekend-tier.yml/badge.svg?branch=main&event=schedule)](https://github.com/goceleris/probatorium/actions/workflows/matrix-weekend-tier.yml?query=event%3Aschedule+branch%3Amain)
+[![Nightly Validation](https://github.com/goceleris/probatorium/actions/workflows/matrix-nightly-tier.yml/badge.svg?branch=main)](https://github.com/goceleris/probatorium/actions/workflows/matrix-nightly-tier.yml?query=branch%3Amain)
+[![Weekend Soak](https://github.com/goceleris/probatorium/actions/workflows/matrix-weekend-tier.yml/badge.svg?branch=main)](https://github.com/goceleris/probatorium/actions/workflows/matrix-weekend-tier.yml?query=branch%3Amain)
 [![Go Reference](https://pkg.go.dev/badge/github.com/goceleris/celeris.svg)](https://pkg.go.dev/github.com/goceleris/celeris)
 [![Go Report Card](https://goreportcard.com/badge/github.com/goceleris/celeris)](https://goreportcard.com/report/github.com/goceleris/celeris)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)


### PR DESCRIPTION
## Why

The probatorium badges in this README were showing blank because they filtered on \`event=schedule\` and the matrix tiers hadn't accumulated a scheduled run yet. Companion fix on probatorium (goceleris/probatorium#127) renames the workflows; this PR keeps the celeris badges in sync.

## What

- \`Matrix Tier — Nightly\` → \`Nightly Validation\`
- \`Matrix Tier — Weekend\` → \`Weekend Soak\`
- Drop \`?event=schedule\` filter so any main-branch run drives the badge.

Pure README edit; no code touched.