### PR TITLE
fix(h1): emit Content-Length: 0 on empty-body responses (keep-alive hang)

### DIFF
--- a/internal/conn/h1_empty_body_test.go
+++ b/internal/conn/h1_empty_body_test.go
@@ -24,12 +24,12 @@ import (
 // the bug for std cells.
 func TestH1ResponseAdapter_EmptyBodyContentLength(t *testing.T) {
 	cases := []struct {
-		name           string
-		status         int
-		headers        [][2]string
-		body           []byte
-		wantCL         string // "" = must NOT appear
-		wantCLAbsent   bool   // explicitly assert no Content-Length (for 1xx/204)
+		name         string
+		status       int
+		headers      [][2]string
+		body         []byte
+		wantCL       string // "" = must NOT appear
+		wantCLAbsent bool   // explicitly assert no Content-Length (for 1xx/204)
 	}{
 		{
 			name:    "301_redirect_no_body",

--- a/internal/conn/h1_empty_body_test.go
+++ b/internal/conn/h1_empty_body_test.go
@@ -1,0 +1,124 @@
+package conn
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestH1ResponseAdapter_EmptyBodyContentLength locks in RFC 9112 §6.2
+// framing for bodiless responses on HTTP/1.1 keep-alive connections.
+//
+// Pre-fix bug discovered via the probatorium nightly run 25988957185:
+// the h1ResponseAdapter (used by iouring + epoll engines) omitted
+// Content-Length: 0 on every empty-body response — including the 301
+// redirects c.Redirect emits and the 4xx/5xx error pages handlers
+// return without a body. Keep-alive clients (Go net/http walker)
+// received the headers + final CRLF, then waited for body bytes
+// forever — exactly the 28k→1.5 req/s collapse the validator saw on
+// static_swagger_proxy iouring/epoll cells the moment the chain
+// stepped through /docs (which redirects to /docs/).
+//
+// std-engine bridge delegated to net/http which framed empty bodies
+// via Transfer-Encoding: chunked + "0\r\n\r\n" terminator, masking
+// the bug for std cells.
+func TestH1ResponseAdapter_EmptyBodyContentLength(t *testing.T) {
+	cases := []struct {
+		name           string
+		status         int
+		headers        [][2]string
+		body           []byte
+		wantCL         string // "" = must NOT appear
+		wantCLAbsent   bool   // explicitly assert no Content-Length (for 1xx/204)
+	}{
+		{
+			name:    "301_redirect_no_body",
+			status:  301,
+			headers: [][2]string{{"location", "/target"}},
+			body:    nil,
+			wantCL:  "content-length: 0\r\n",
+		},
+		{
+			name:    "302_redirect_no_body",
+			status:  302,
+			headers: [][2]string{{"location", "/target"}},
+			body:    nil,
+			wantCL:  "content-length: 0\r\n",
+		},
+		{
+			name:    "400_no_body",
+			status:  400,
+			headers: nil,
+			body:    nil,
+			wantCL:  "content-length: 0\r\n",
+		},
+		{
+			name:    "500_no_body",
+			status:  500,
+			headers: nil,
+			body:    nil,
+			wantCL:  "content-length: 0\r\n",
+		},
+		{
+			name:    "200_no_body_via_NoContent",
+			status:  200,
+			headers: nil,
+			body:    nil,
+			wantCL:  "content-length: 0\r\n",
+		},
+		{
+			name:         "204_no_content_omits_content_length",
+			status:       204,
+			headers:      nil,
+			body:         nil,
+			wantCLAbsent: true,
+		},
+		{
+			name:         "304_not_modified_omits_content_length",
+			status:       304,
+			headers:      [][2]string{{"etag", "\"v1\""}},
+			body:         nil,
+			wantCLAbsent: true,
+		},
+		{
+			name:         "100_continue_omits_content_length",
+			status:       100,
+			headers:      nil,
+			body:         nil,
+			wantCLAbsent: true,
+		},
+		{
+			name:    "200_with_body_keeps_content_length",
+			status:  200,
+			headers: [][2]string{{"content-type", "application/json"}},
+			body:    []byte(`{"ok":1}`),
+			wantCL:  "content-length: 8\r\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var captured bytes.Buffer
+			adapter := &h1ResponseAdapter{
+				write:     func(p []byte) { captured.Write(p) },
+				keepAlive: true,
+			}
+			if err := adapter.WriteResponse(nil, tc.status, tc.headers, tc.body); err != nil {
+				t.Fatalf("WriteResponse: %v", err)
+			}
+			out := captured.String()
+			// Case-insensitive header check: the adapter emits lowercase
+			// names; the constants in this file use lowercase too.
+			lower := strings.ToLower(out)
+			if tc.wantCLAbsent {
+				if strings.Contains(lower, "content-length:") {
+					t.Errorf("unexpected content-length present:\n%s", out)
+				}
+				return
+			}
+			if !strings.Contains(lower, tc.wantCL) {
+				t.Errorf("missing %q in response:\n%s", tc.wantCL, out)
+			}
+		})
+	}
+}

--- a/internal/conn/response.go
+++ b/internal/conn/response.go
@@ -176,6 +176,33 @@ func (a *h1ResponseAdapter) Hijack(_ *stream.Stream) (net.Conn, error) {
 
 var _ stream.Hijacker = (*h1ResponseAdapter)(nil)
 
+// mustFrameEmptyBody reports whether an HTTP/1.1 response with no body
+// requires explicit framing (Content-Length: 0 or Transfer-Encoding) on
+// a keep-alive connection.
+//
+// RFC 9110 §15 + RFC 9112 §6.2:
+//
+//   - 1xx (Informational) and 204 (No Content) MUST NOT include
+//     Content-Length, and have no body — keep-alive parsers know they
+//     finish at the trailing CRLF, no framing required.
+//   - 304 (Not Modified) — Content-Length is optional, and parsers
+//     never expect a body. We omit it for symmetry with 1xx/204.
+//   - Every other status (2xx ≠ 204, 3xx, 4xx, 5xx) with an empty body
+//     MUST advertise the absence to the keep-alive client; otherwise
+//     the client waits for body bytes forever — exactly the hang
+//     observed by the probatorium walker against iouring/epoll when
+//     it received a 301 redirect from c.Redirect / c.NoContent.
+func mustFrameEmptyBody(status int) bool {
+	switch {
+	case status >= 100 && status < 200:
+		return false
+	case status == 204, status == 304:
+		return false
+	default:
+		return true
+	}
+}
+
 func (a *h1ResponseAdapter) WriteResponse(_ *stream.Stream, status int, headers [][2]string, body []byte) error {
 	// Reuse per-connection buffer. This eliminates sync.Pool Get/Put
 	// per response (~40ns). The buffer grows as needed and persists
@@ -299,7 +326,7 @@ func (a *h1ResponseAdapter) WriteResponse(_ *stream.Stream, status int, headers 
 			buf = append(buf, h[1]...)
 			buf = append(buf, crlf...)
 		}
-		if !hasContentLength && len(body) > 0 {
+		if !hasContentLength && (len(body) > 0 || mustFrameEmptyBody(status)) {
 			buf = append(buf, clPrefix...)
 			buf = strconv.AppendInt(buf, int64(len(body)), 10)
 			buf = append(buf, crlf...)


### PR DESCRIPTION
## Why

Probatorium nightly run [25988957185](https://github.com/goceleris/probatorium/actions/runs/25988957185) surfaced a 10000× throughput collapse on the static_swagger_proxy validation refapp when iouring/epoll engines were paired with any Markov chain step that hit a route returning a bodiless response — `/docs` redirecting to `/docs/` was the canary.

Cluster reproducer (Go walker, HTTP/1.1 keep-alive):

| Engine | Pre-fix (5 s, multi-path probe) | Post-fix |
|---|---|---|
| std | 102 053 reqs (delegates to net/http: chunked + 0\r\n\r\n) | ≈ same |
| epoll | **4 reqs total — walker hung on `/docs`** | **114 606 reqs** |
| iouring | **4 reqs total — walker hung on `/docs`** | **118 169 reqs** |

## Root cause

`h1ResponseAdapter.WriteResponse` only emitted `Content-Length` when the body had bytes. Bodiless responses (every `c.Redirect`, every `c.NoContent`, every routed error page) went out with neither `Content-Length` nor `Transfer-Encoding` — so HTTP/1.1 keep-alive clients waited for body bytes forever.

`std`-engine bridge delegates to net/http, which auto-frames empty bodies as `Transfer-Encoding: chunked` + `0\r\n\r\n`. That masked the bug for std-only refapp cells across every previous validate / soak.

## Fix

When body is empty and no `Content-Length` is already set, emit `content-length: 0\r\n` — UNLESS the status forbids it per RFC 9112 §6.2 / RFC 9110 §15:

- 1xx Informational
- 204 No Content
- 304 Not Modified

New helper `mustFrameEmptyBody(status int) bool` encapsulates that switch.

## Test plan

- [x] New unit test `TestH1ResponseAdapter_EmptyBodyContentLength` — 9 sub-cases pinning the wire shape for 100 / 200 (with body & empty) / 204 / 301 / 302 / 304 / 400 / 500.
- [x] `go vet ./...` + `go build ./...` clean.
- [x] Cluster reproducer confirmed fixed (numbers above).
- [ ] Next probatorium nightly: kitchen_sink + observability + static_swagger_proxy iouring + epoll cells produce millions of requests instead of a few hundred.