### PR TITLE
fix(context) + feat(config): respHdrBuf overflow panic + scaler default-on

### DIFF
--- a/context.go
+++ b/context.go
@@ -545,6 +545,23 @@ func (c *Context) reset() {
 	c.fullPath = ""
 	c.statusCode = 200
 	if n := len(c.respHeaders); n > 0 {
+		// respHeaders shares the respHdrBuf backing array up to its
+		// fixed capacity (16). Middleware stacks that emit more than 16
+		// response headers (kitchen_sink with secure + cache + ratelimit
+		// + etag etc. easily exceeds it) trigger append() to allocate a
+		// new backing array — respHeaders now has > 16 entries but
+		// respHdrBuf is still just 16. Without this clamp,
+		// `clear(c.respHdrBuf[:n])` panics with "slice bounds out of
+		// range [:N] with length 16" — the panic propagates through
+		// recoverAndRelease and aborts the iouring/epoll async handler
+		// AFTER WriteResponse has queued bytes into the per-conn
+		// writeBuf but BEFORE flushSend pushes them to the socket, so
+		// the client sees an empty response. std-engine escapes the
+		// damage because Go's net/http writes the response inline
+		// before the cleanup panic.
+		if n > len(c.respHdrBuf) {
+			n = len(c.respHdrBuf)
+		}
 		clear(c.respHdrBuf[:n])
 	}
 	c.respHeaders = c.respHdrBuf[:0]

--- a/context_test.go
+++ b/context_test.go
@@ -3,6 +3,7 @@ package celeris
 import (
 	"context"
 	"net"
+	"strconv"
 	"testing"
 	"time"
 
@@ -199,6 +200,52 @@ func TestContextFullPath(t *testing.T) {
 	c.fullPath = "/users/:id"
 	if c.FullPath() != "/users/:id" {
 		t.Fatalf("expected /users/:id, got %q", c.FullPath())
+	}
+}
+
+// TestContextResetWithOverflowedRespHeaders locks in the overflow-safe
+// reset path. Pre-fix (probatorium nightly 25993346060 root cause) a
+// middleware stack that emitted ≥ 17 response headers (kitchen_sink:
+// recovery + requestid + secure × 8 + cors + ratelimit × 3 + etag +
+// cache + x-cache + x-request-id) caused c.reset() to slice the
+// fixed-size respHdrBuf beyond its capacity:
+//
+//	clear(c.respHdrBuf[:n])  →  panic: runtime error: slice bounds
+//	                            out of range [:17] with length 16
+//
+// On the iouring/epoll engines the panic propagated through
+// recoverAndRelease AFTER WriteResponse had queued bytes into the
+// per-conn writeBuf but BEFORE the worker's flushSend pushed those
+// bytes to the socket — the client saw zero bytes, the connection
+// stalled, the validator's walker timed out. std-engine escaped
+// the wire-visible damage because net/http writes inline.
+func TestContextResetWithOverflowedRespHeaders(t *testing.T) {
+	s, _ := newTestStream("GET", "/test")
+	defer s.Release()
+
+	c := acquireContext(s)
+	// Push 20 headers — overflows respHdrBuf (16 slots) and forces
+	// append() to allocate a new backing array.
+	for i := 0; i < 20; i++ {
+		c.SetHeader("x-test-"+strconv.Itoa(i), "v")
+	}
+	if got := len(c.respHeaders); got != 20 {
+		t.Fatalf("expected 20 headers staged, got %d", got)
+	}
+
+	// Pre-fix this would panic with "slice bounds out of range
+	// [:20] with length 16". Recover so the test framework reports
+	// the panic clearly rather than crashing the whole process.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("reset panicked with overflowed respHeaders: %v", r)
+		}
+	}()
+	releaseContext(c)
+
+	// After release, respHeaders is reset back to respHdrBuf[:0].
+	if cap(c.respHeaders) < len(c.respHdrBuf) {
+		t.Fatalf("respHeaders capacity collapsed below respHdrBuf size: cap=%d", cap(c.respHeaders))
 	}
 }
 


### PR DESCRIPTION
Two changes for the v1.4.6 release.

## 1. fix(context): clamp respHdrBuf clear() on overflow to prevent reset panic

Investigation of the probatorium nightly [25993346060](https://github.com/goceleris/probatorium/actions/runs/25993346060): kitchen_sink iouring/epoll cells collapsed to ~3 req/s and \`/api/echo\` came back empty. The iouring async-handler logged a recovered panic:

\`\`\`
runtime error: slice bounds out of range [:17] with length 16
goroutine ... github.com/goceleris/celeris.(*Context).reset(...)
  context.go:548 +0x526
\`\`\`

Root cause: \`c.respHeaders\` is initialised over the fixed \`[16][2]string respHdrBuf\`. The 17th \`SetHeader\` forces \`append()\` to allocate fresh — \`respHeaders.len > respHdrBuf.len\` from then on. \`reset()\` then sliced \`respHdrBuf[:n]\` where n was \`len(c.respHeaders)\` → out of bounds → panic.

Middleware stacks cross 16 easily: kitchen_sink emits secure (8 security headers) + cors + ratelimit (3 X-RateLimit-*) + etag + cache + requestid + handler content-type/content-length = 17–20.

**Wire-visible damage path (iouring + epoll only):** WriteResponse queues bytes into the per-conn writeBuf, then \`recoverAndRelease\` runs \`reset()\` → panic → async-handler recover catches it, but the engine's \`flushSend\` never runs. Client sees zero bytes. std-engine writes inline via net/http, so the wire response is sent before cleanup damage.

**Fix:** clamp \`clear()\` to \`min(n, len(respHdrBuf))\`.

### Cluster verification — kitchen_sink \`/api/echo\` + 4 sibling routes, single-walker 5 s probe

| Engine | Pre-fix | Post-fix |
|---|---|---|
| std | 22 271 req/s | 22 271 req/s (unchanged — wasn't affected) |
| **iouring** | **3 req/s** | **28 077 req/s** |
| **epoll** | **3 req/s** | **27 781 req/s** |

## 2. feat(config): dynamic worker scaler default-on (issue #281)

Aligns the third \"just-works\" public default with the existing two:

| Default | Pre-v1.4.6 | v1.4.6 |
|---|---|---|
| Engine | Adaptive | Adaptive |
| Protocol | Auto | Auto |
| **Scaler** | **disabled** | **enabled** |

\`celeris.Config.WorkerScaling\` now resolves to a non-nil zero-value \`resource.WorkerScalingConfig\` when the user leaves it unset. The scaler activates with the data-validated defaults from #244 / #257:

- Strategy: StartHigh
- MinActive: max(2, NumCPU/2)
- TargetConnsPerWorker: 20
- Interval: 250 ms
- ScaleUpStep: 2, ScaleDownStep: 1, ScaleDownHysteresis: 1, ScaleDownIdleTicks: 4

### Opt-out

Pre-v1.4.6 behaviour (always-on workers) is reachable via:

\`\`\`go
cfg.WorkerScaling = &resource.WorkerScalingConfig{
    MinActive: runtime.GOMAXPROCS(0), // pin active = NumCPU
}
\`\`\`

\`resource.Config.WorkerScaling\` stays nil-as-disabled — the substitution happens inside \`celeris.Config.toResourceConfig\` so engine-level callers that build \`resource.Config\` directly (test infrastructure) keep their legacy contract.

## Test plan

- [x] \`TestContextResetWithOverflowedRespHeaders\` — pre-fix panics, post-fix returns cleanly.
- [x] \`TestConfigWorkerScalingDefaultOn\` — nil resolves to non-nil zero-value struct.
- [x] \`TestConfigWorkerScalingExplicitPreserved\` — explicit pointer passed through verbatim.
- [x] \`go vet ./...\` clean.
- [x] \`go test ./...\` all green.
- [ ] Probatorium weekend (24h) tier validates the default-on scaler across all refapps × all engines × both archs (#281 last AC).