### PR TITLE
feat(config): dynamic worker scaler default-on (#281)

### DIFF
--- a/config.go
+++ b/config.go
@@ -155,15 +155,32 @@ type Config struct {
 	//     the engine intentionally only serves HTTP/1.
 	EnableH2Upgrade *bool
 
-	// WorkerScaling configures the dynamic worker scaler. Nil disables
-	// scaling — the engine runs Workers workers all the time (legacy
-	// behaviour). Set to a non-nil pointer (zero-value struct OK) to
-	// enable scaling with sensible defaults; see resource.WorkerScalingConfig
-	// for tuning. The scaler keeps connections-per-active-worker around
-	// the target ratio by pausing/resuming workers; this dramatically
-	// improves CQE/event batching at low/mid concurrency where the static
-	// numCPU default would otherwise lose 30-90 % CPU/req to under-batched
-	// syscalls. See PR #257 for the full rationale and benchmark data.
+	// WorkerScaling configures the dynamic worker scaler. As of v1.4.6
+	// the scaler is DEFAULT-ON — leaving this field nil resolves to a
+	// zero-value [resource.WorkerScalingConfig], which activates the
+	// scaler with the data-validated defaults (Strategy=StartHigh,
+	// MinActive=max(2, NumCPU/2), TargetConnsPerWorker=20,
+	// Interval=250ms, ScaleUpStep=2, ScaleDownStep=1,
+	// ScaleDownHysteresis=1, ScaleDownIdleTicks=4). This matches the
+	// "just-works" public design intent already in place for the
+	// Engine=Adaptive and Protocol=Auto defaults.
+	//
+	// Pre-v1.4.6 behaviour (scaler always disabled unless explicitly
+	// configured) is achievable by passing a non-nil struct that
+	// effectively makes the scaler a no-op:
+	//
+	//	WorkerScaling: &resource.WorkerScalingConfig{
+	//	    MinActive: runtime.GOMAXPROCS(0), // pin at NumCPU; never scale down
+	//	}
+	//
+	// Set to a non-nil pointer with custom values to override one or
+	// more defaults. See [resource.WorkerScalingConfig] for tuning.
+	// The scaler keeps connections-per-active-worker around the target
+	// ratio by pausing/resuming workers; this dramatically improves
+	// CQE/event batching at low/mid concurrency where the static
+	// numCPU default would otherwise lose 30-90 % CPU/req to under-
+	// batched syscalls. See PR #257 / issue #281 for the full
+	// rationale and benchmark data.
 	WorkerScaling *resource.WorkerScalingConfig
 }
 
@@ -215,7 +232,17 @@ func (c Config) toResourceConfig() resource.Config {
 	rc.OnExpectContinue = c.OnExpectContinue
 	rc.OnConnect = c.OnConnect
 	rc.OnDisconnect = c.OnDisconnect
-	rc.WorkerScaling = c.WorkerScaling
+	// Dynamic worker scaler default-on (issue #281). A nil
+	// WorkerScaling field — i.e. the user did not configure it — now
+	// resolves to a zero-value struct so the scaler activates with
+	// the data-validated defaults. Opt-out is documented as setting
+	// MinActive=NumCPU (no-op scaler), which preserves backward
+	// compatibility for users who really do want pre-v1.4.6 behaviour.
+	if c.WorkerScaling != nil {
+		rc.WorkerScaling = c.WorkerScaling
+	} else {
+		rc.WorkerScaling = &resource.WorkerScalingConfig{}
+	}
 
 	// h2c upgrade resolution. Nil → protocol-dependent default (Auto → true,
 	// HTTP1/H2C → false). Non-nil → user override honored verbatim.

--- a/resource/config.go
+++ b/resource/config.go
@@ -73,11 +73,17 @@ type Config struct {
 	// sub-engine, so the iouring + epoll built-in scalers must stay quiet
 	// to avoid two scalers fighting over the same worker pool.
 	SkipBuiltinScaler bool
-	// WorkerScaling configures the dynamic worker scaler. Nil disables the
-	// scaler (default — workers stays at Resources.Workers and never adapts).
+	// WorkerScaling configures the dynamic worker scaler. As of v1.4.6
+	// (issue #281), [celeris.Config.toResourceConfig] sets this to a
+	// zero-value struct whenever the user-facing field was nil — the
+	// scaler is therefore DEFAULT-ON for any user constructing the
+	// server via celeris.New. Direct callers of resource.Config (i.e.
+	// engine tests + the resource_test suite) still see nil-as-disabled
+	// to keep the legacy contract for that low-level surface.
+	//
 	// When set, the scaler activates and deactivates workers based on
-	// observed load to keep CQE/event batching density in the sweet spot.
-	// See WorkerScalingConfig for tuning details.
+	// observed load to keep CQE/event batching density in the sweet
+	// spot. See WorkerScalingConfig for tuning details.
 	WorkerScaling *WorkerScalingConfig
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/goceleris/celeris/engine"
 	"github.com/goceleris/celeris/protocol/h2/stream"
+	"github.com/goceleris/celeris/resource"
 )
 
 func TestServerEngineInfo(t *testing.T) {
@@ -1011,6 +1012,43 @@ func TestConfigZeroValuesNotMapped(t *testing.T) {
 	}
 	if rc.Resources.MaxConns != 0 {
 		t.Fatalf("expected 0 MaxConns, got %d", rc.Resources.MaxConns)
+	}
+}
+
+// TestConfigWorkerScalingDefaultOn pins the v1.4.6 default-on contract
+// for issue #281: nil Config.WorkerScaling resolves to a non-nil,
+// zero-value resource.WorkerScalingConfig — the scaler activates
+// automatically with the data-validated defaults
+// (Strategy=StartHigh, MinActive=max(2,NumCPU/2),
+// TargetConnsPerWorker=20, Interval=250ms, ScaleUpStep=2,
+// ScaleDownStep=1, ScaleDownHysteresis=1, ScaleDownIdleTicks=4).
+//
+// This brings the "just-works" public design intent (Adaptive engine,
+// Auto protocol) into alignment for the third major default.
+func TestConfigWorkerScalingDefaultOn(t *testing.T) {
+	cfg := Config{Addr: ":8080"} // no WorkerScaling field set
+	rc := cfg.toResourceConfig()
+	if rc.WorkerScaling == nil {
+		t.Fatal("nil Config.WorkerScaling did not resolve to a non-nil resource.WorkerScalingConfig — scaler default-on regressed")
+	}
+	if *rc.WorkerScaling != (resource.WorkerScalingConfig{}) {
+		t.Fatalf("expected zero-value WorkerScalingConfig (so scaler picks data-validated defaults), got %+v", *rc.WorkerScaling)
+	}
+}
+
+// TestConfigWorkerScalingExplicitPreserved pins that user-supplied
+// values are passed through verbatim: the default-on path only fires
+// when the user did NOT configure the scaler.
+func TestConfigWorkerScalingExplicitPreserved(t *testing.T) {
+	want := &resource.WorkerScalingConfig{
+		Strategy:             resource.ScalingStrategyStartLow,
+		MinActive:            7,
+		TargetConnsPerWorker: 99,
+	}
+	cfg := Config{Addr: ":8080", WorkerScaling: want}
+	rc := cfg.toResourceConfig()
+	if rc.WorkerScaling != want {
+		t.Fatalf("explicit WorkerScaling pointer was not preserved: got %p, want %p", rc.WorkerScaling, want)
 	}
 }
 


### PR DESCRIPTION
Closes #281.

## Why

Aligns the third \"just-works\" public default with the existing two:

| Default | Pre-v1.4.6 | v1.4.6 |
|---|---|---|
| Engine | Adaptive | Adaptive |
| Protocol | Auto | Auto |
| **Scaler** | **disabled** | **enabled** |

Per the issue, this completes the unchecked \"Default-on once validation criteria pass\" item from #257.

## What

\`celeris.Config.WorkerScaling\` resolves to a non-nil zero-value \`resource.WorkerScalingConfig\` when the user-facing field is nil. The scaler then activates with the data-validated defaults from the spike-B sweep (#244/#257):

- Strategy: StartHigh
- MinActive: max(2, NumCPU/2)
- TargetConnsPerWorker: 20
- Interval: 250 ms
- ScaleUpStep: 2, ScaleDownStep: 1, ScaleDownHysteresis: 1, ScaleDownIdleTicks: 4

Substitution happens inside \`Config.toResourceConfig\` so direct \`resource.Config\` callers (engine tests, the resource_test suite) keep the legacy nil-as-disabled contract for that low-level surface.

## Opt-out

Pre-v1.4.6 behaviour (workers always active) is reachable via:

\`\`\`go
cfg.WorkerScaling = &resource.WorkerScalingConfig{
    MinActive: runtime.GOMAXPROCS(0), // pin active = NumCPU, scaler is a no-op
}
\`\`\`

Documented inline on the \`Config.WorkerScaling\` field.

## Test plan

- [x] \`TestConfigWorkerScalingDefaultOn\` — nil resolves to non-nil zero-value struct.
- [x] \`TestConfigWorkerScalingExplicitPreserved\` — explicit pointer preserved verbatim.
- [x] \`go vet ./...\` + \`go test ./...\` all green locally.
- [ ] Probatorium weekend (24 h) tier across all refapps × all engines × both archs — closes #281 last AC.