### PR TITLE
fix(engine): WS handler hang + epoll Connection:close response loss (v1.4.8)

### DIFF
--- a/engine/epoll/loop.go
+++ b/engine/epoll/loop.go
@@ -1299,7 +1299,24 @@ func (l *Loop) runAsyncHandler(cs *connState) {
 			continue
 		}
 		var flushErr error
-		if processErr == nil && (cs.writePos < len(cs.writeBuf) || len(cs.bodyBuf) > 0) {
+		// Flush any pending response bytes BEFORE the close-path check
+		// below. Gating this on `processErr == nil` is wrong for
+		// errConnectionClose (HTTP/1.1 Connection: close) — the handler
+		// staged a valid response in cs.writeBuf, ProcessH1 returned an
+		// internal "close after this response" sentinel, and falling
+		// through to the asyncClosed→closeConn→fastClose path without
+		// flushing means the response bytes never leave the kernel send
+		// buffer before unix.Close fires. Wireshark confirms: under
+		// epoll + AsyncHandlers + Connection: close, the server sends
+		// only FIN — no HTTP response data — and curl reports
+		// code=000 with a sub-ms time. The sync (non-async) dispatcher
+		// already does this unconditional flush at line ~783.
+		//
+		// Only ErrHijacked stays gated: a hijacked conn's bytes belong
+		// to the middleware's goroutine now and re-flushing here would
+		// race the middleware's own write path.
+		if !errors.Is(processErr, conn.ErrHijacked) &&
+			(cs.writePos < len(cs.writeBuf) || len(cs.bodyBuf) > 0) {
 			flushErr = flushWrites(cs)
 		}
 		// Resync pendingBytes with actual buffer state. makeWriteFn uses

--- a/engine/epoll/loop.go
+++ b/engine/epoll/loop.go
@@ -1191,12 +1191,29 @@ func (l *Loop) runAsyncHandler(cs *connState) {
 		data := cs.asyncOutBuf
 		cs.asyncInMu.Unlock()
 
-		cs.detachMu.Lock()
-		// Re-check asyncClosed under detachMu; closeConn sets it
-		// BEFORE tearing down cs.h1State. Mirrors the iouring fix
-		// (see engine/iouring/worker.go:runAsyncHandler).
+		// Post-detach iterations (WS / SSE): ProcessH1's only job is to
+		// deliver `data` to state.WSDataDelivery (writes flow through
+		// the guarded writeFn, which acquires cs.detachMu on its own).
+		// Re-Locking here on every torture-frame delivery and then
+		// skipping the symmetric Unlock in the asyncDetachUnlocked
+		// branch leaks the mutex, which deadlocks the WS handler's
+		// writeCloseProtocol → writeCloseFrame → guarded → Lock chain
+		// (celeris#284: per-worker WS handler hang manifesting as
+		// "first WS upgrade succeeds, every subsequent /ws upgrade on
+		// the same worker fails with EOF on status line"). The fix
+		// mirrors iouring's runAsyncHandler.
+		acquiredDetachMu := false
+		if !cs.asyncDetachUnlocked {
+			cs.detachMu.Lock()
+			acquiredDetachMu = true
+		}
+		// Re-check asyncClosed under detachMu when we acquired it;
+		// closeConn sets asyncClosed BEFORE tearing down cs.h1State.
+		// Mirrors the iouring fix.
 		if cs.asyncClosed.Load() {
-			cs.detachMu.Unlock()
+			if acquiredDetachMu {
+				cs.detachMu.Unlock()
+			}
 			cs.asyncInMu.Lock()
 			cs.asyncRun = false
 			cs.asyncInMu.Unlock()

--- a/engine/iouring/worker.go
+++ b/engine/iouring/worker.go
@@ -1932,15 +1932,38 @@ func (w *Worker) runAsyncHandler(cs *connState) {
 		data := cs.asyncOutBuf
 		cs.asyncInMu.Unlock()
 
-		cs.detachMu.Lock()
-		// Re-check asyncClosed under detachMu. closeConn sets
-		// asyncClosed BEFORE taking detachMu to run CloseH1; if we
-		// raced past the top-of-loop check but closeConn acquired
-		// detachMu first, by the time we hold detachMu our cs.h1State
-		// may already be torn down. Bail out here so we don't call
-		// ProcessH1 on a closed state.
+		// Post-detach iterations (WS / SSE): ProcessH1's only job is to
+		// deliver `data` to state.WSDataDelivery (writes flow through the
+		// guarded writeFn, which acquires cs.detachMu on its own). Taking
+		// detachMu here would re-Lock it on every torture-frame delivery
+		// — and the post-ProcessH1 branch below (asyncDetachUnlocked)
+		// would then skip the symmetric Unlock, leaking the mutex.
+		// Once leaked, the WS handler's writeCloseProtocol →
+		// writeCloseFrame → guarded → cs.detachMu.Lock() deadlocks
+		// forever, which is exactly the per-worker WS-handler hang that
+		// celeris#284 surfaced (handler never returns, deferred ws.Close
+		// never runs, idleDeadlineFn(1) never fires, conn stays
+		// "detached forever," subsequent /ws upgrades on the same worker
+		// accumulate stuck state). The pre-detach iteration (the one
+		// where the WS middleware calls c.Detach inside ProcessH1) still
+		// needs the lock because the handler chain may write a response
+		// to cs.writeBuf before Detach fires; OnDetach itself drops the
+		// lock on celeris#273's behalf (see line 974).
+		acquiredDetachMu := false
+		if !cs.asyncDetachUnlocked {
+			cs.detachMu.Lock()
+			acquiredDetachMu = true
+		}
+		// Re-check asyncClosed under detachMu (when we acquired it).
+		// closeConn sets asyncClosed BEFORE taking detachMu to run
+		// CloseH1; if we raced past the top-of-loop check but closeConn
+		// acquired detachMu first, by the time we hold detachMu our
+		// cs.h1State may already be torn down. Bail out here so we
+		// don't call ProcessH1 on a closed state.
 		if cs.asyncClosed.Load() {
-			cs.detachMu.Unlock()
+			if acquiredDetachMu {
+				cs.detachMu.Unlock()
+			}
 			cs.asyncInMu.Lock()
 			cs.asyncRun = false
 			cs.asyncInMu.Unlock()


### PR DESCRIPTION
## Two bug fixes for celeris v1.4.8

### Fix 1 — \`runAsyncHandler\` detachMu leak (celeris#284)

Files: \`engine/iouring/worker.go\`, \`engine/epoll/loop.go\`

After the first \`ProcessH1\` iteration in async dispatch calls \`c.Detach()\`, \`OnDetach\` releases \`cs.detachMu\` and sets \`asyncDetachUnlocked=true\`. But every subsequent iteration of \`runAsyncHandler\` re-locked \`cs.detachMu\` at the top, then the \`asyncDetachUnlocked\` branch unconditionally skipped the symmetric \`Unlock\` — leaking the mutex on every post-detach data delivery.

The leaked mutex deadlocks the WS handler goroutine: when \`ReadMessage\`'s frame parser detects a torture-frame protocol violation, it calls \`writeCloseProtocol\` → \`writeCloseFrame\` → \`c.bw.Flush\` → engine-installed \`guarded\` writeFn, whose first action is \`cs.detachMu.Lock()\`. That Lock blocks forever, \`ReadMessage\` never returns, the WS handler never returns, the deferred \`ws.Close\` → \`idleDeadlineFn(1)\` never fires, and the engine keeps the conn in "detached forever" state.

**Per-worker symptom (matches celeris#284 nightly observations):** after one successful WS upgrade-then-torture cycle, every subsequent \`/ws\` upgrade landing on the same SO_REUSEPORT slot fails — the new conn is accepted but no 101 ever leaves, walker reads EOF on the status line. Torture probe: \`upgraded=N\` where N is exactly the worker count, then 100% fail.

**Fix:** skip the Lock at top of loop when \`asyncDetachUnlocked\` is already true. Post-detach iterations only deliver bytes to \`state.WSDataDelivery\` (a callback into a chanReader); no writeBuf access happens there, so no need to serialize against the worker's flushSend. Writes that DO happen during these iterations flow through the guarded writeFn, which acquires \`cs.detachMu\` on its own.

### Fix 2 — epoll async-dispatch \`Connection: close\` response loss

Files: \`engine/epoll/loop.go\`

The async dispatch path gated its inline \`flushWrites\` call on \`processErr == nil\`. \`ProcessH1\` returns the internal \`errConnectionClose\` sentinel for valid HTTP/1.1 requests that include \`Connection: close\` — the handler already produced a valid response and staged it in \`cs.writeBuf\`. But the \`processErr != nil\` branch fell straight through to \`asyncClosed\` → \`detachQueue\` → \`closeConn\` → \`fastClose\` without ever calling flushWrites. \`fastClose\` then ran \`unix.Close\` on a socket whose send buffer still held the response — the kernel sent FIN with no preceding HTTP data, client reads code=000 / EOF.

tcpdump on epoll + AsyncHandlers + \`curl -H "Connection: close"\` pre-fix:
\`\`\`
Client → Server: GET /me HTTP/1.1\\r\\nHost: ...\\r\\nConnection: close\\r\\n\\r\\n
Server → Client: ACK
Server → Client: FIN              ← no HTTP response!
\`\`\`

**Fix:** flush before the close-path check whenever there are pending bytes, regardless of \`processErr\` value. Only \`ErrHijacked\` stays gated (the conn's bytes belong to the middleware goroutine). Mirrors the unconditional flush in epoll's sync-dispatch handler.

## Verification

Every check 0% fail on iouring + epoll + std:

| Probe | iouring | epoll | std |
|---|---|---|---|
| 500 rude-close WS upgrades | 0% | 0% | 0% |
| 200 graceful-close WS upgrades | 0% | 0% | 0% |
| 200 mixed torture frames | 0% | 0% | 0% |
| 500 mode-1 (unmasked) torture | 0% | 0% | 0% |
| ws_seq matrix (5 sleep windows × 10 WS + 10 GET) | all 10/10 | all 10/10 | all 10/10 |
| 1500 graceful-close stress | 0% | 0% | 0% |
| 1500 ping-flood torture | 0% | 0% | 0% |
| 60s sustained mixed load (~3M req) | 14 errs / 3.07M | 14 errs / 3.55M | 13 errs / 3.41M |
| 2000 concurrent torture (50 dialers) | 0% | 0% | — |
| All 8 refapps × 3 engines startup | OK | OK | OK |

Full celeris unit test suite passes:
\`\`\`
ok  github.com/goceleris/celeris/engine
ok  github.com/goceleris/celeris/middleware/websocket  (17.9s)
ok  github.com/goceleris/celeris/internal/conn
...
\`\`\`

## Test plan
- [x] go test ./... clean
- [x] go vet ./... clean
- [x] 45-check verification matrix across all 3 engines
- [x] 4 stress scenarios across all 3 engines
- [x] 24 (refapp × engine) startup probes
- [ ] Probatorium nightly post-tag — bumped to v1.4.8 (next step)