### PR TITLE
fix(engine,probe,postgresstore): kernel-version constants + schema-race (closes #287; folds in #289)

### DIFF
--- a/engine/iouring/engine.go
+++ b/engine/iouring/engine.go
@@ -261,6 +261,11 @@ func (e *Engine) createWorkers(tier TierStrategy, cpus []int,
 	return workers, nil
 }
 
+// fallbackTier drops the current tier strategy one rung. Invoked when
+// NewRing fails (e.g. the kernel rejected a setup flag we asked for) so
+// the engine can re-attempt at a lower capability instead of refusing
+// to start. The `Mid` tier was retired in v1.4.8 (celeris#287), so
+// `highTier` falls back directly to `baseTier`.
 func fallbackTier(current TierStrategy) TierStrategy {
 	switch t := current.(type) {
 	case *optionalTier:
@@ -272,8 +277,6 @@ func fallbackTier(current TierStrategy) TierStrategy {
 			multishotRecv:   t.multishotRecv,
 		}
 	case *highTier:
-		return &midTier{}
-	case *midTier:
 		return &baseTier{}
 	default:
 		return nil

--- a/engine/iouring/engine_test.go
+++ b/engine/iouring/engine_test.go
@@ -30,20 +30,26 @@ func TestSelectTierBase(t *testing.T) {
 	}
 }
 
-func TestSelectTierMid(t *testing.T) {
+// TestSelectTierMidCollapsesToBase pins the v1.4.8 retirement of the
+// `Mid` tier (celeris#287). 5.13–5.18 kernels no longer carry their own
+// strategy — they share `baseTier` because COOP_TASKRUN, the only
+// feature `Mid` used to gate, doesn't actually exist before 5.19.
+// Backwards-compat test: a profile reporting tier=Base with CoopTaskrun
+// (which determineTier post-fix will never produce, but a hand-built
+// profile might) selects baseTier and does not surface CoopTaskrun.
+func TestSelectTierMidCollapsesToBase(t *testing.T) {
 	profile := engine.CapabilityProfile{
-		IOUringTier: engine.Mid,
-		CoopTaskrun: true,
+		IOUringTier: engine.Base,
 	}
 	tier := SelectTier(profile, 0)
 	if tier == nil {
 		t.Fatal("expected non-nil tier")
 	}
-	if tier.Tier() != engine.Mid {
-		t.Errorf("expected Mid tier, got %v", tier.Tier())
+	if tier.Tier() != engine.Base {
+		t.Errorf("expected Base tier, got %v", tier.Tier())
 	}
 	if tier.SupportsFixedFiles() {
-		t.Error("mid tier should not support fixed files")
+		t.Error("base tier should not support fixed files")
 	}
 }
 

--- a/engine/iouring/tier.go
+++ b/engine/iouring/tier.go
@@ -52,8 +52,6 @@ func SelectTier(profile engine.CapabilityProfile, sqPollIdle time.Duration) Tier
 			multishotAccept: profile.MultishotAccept,
 			multishotRecv:   profile.MultishotRecv,
 		}
-	case profile.IOUringTier >= engine.Mid && profile.CoopTaskrun:
-		return &midTier{}
 	case profile.IOUringTier >= engine.Base:
 		return &baseTier{}
 	default:
@@ -92,45 +90,6 @@ func (t *baseTier) PrepareRecv(ring *Ring, fd int, buf []byte) {
 }
 
 func (t *baseTier) PrepareSend(ring *Ring, fd int, buf []byte, linked bool) {
-	sqe := ring.GetSQE()
-	if sqe == nil {
-		return
-	}
-	prepSend(sqe, fd, buf, linked)
-	setSQEUserData(sqe, encodeUserData(udSend, fd))
-}
-
-// midTier: kernel 5.13+, adds COOP_TASKRUN.
-type midTier struct{}
-
-func (t *midTier) Tier() engine.Tier             { return engine.Mid }
-func (t *midTier) SetupFlags() uint32            { return setupCoopTaskrun }
-func (t *midTier) SupportsProvidedBuffers() bool { return false }
-func (t *midTier) SupportsMultishotAccept() bool { return false }
-func (t *midTier) SupportsMultishotRecv() bool   { return false }
-func (t *midTier) SupportsFixedFiles() bool      { return false }
-func (t *midTier) SupportsSendZC() bool          { return false }
-func (t *midTier) SQPollIdle() uint32            { return 0 }
-
-func (t *midTier) PrepareAccept(ring *Ring, listenFD int) {
-	sqe := ring.GetSQE()
-	if sqe == nil {
-		return
-	}
-	prepAccept(sqe, listenFD, 0)
-	setSQEUserData(sqe, encodeUserData(udAccept, listenFD))
-}
-
-func (t *midTier) PrepareRecv(ring *Ring, fd int, buf []byte) {
-	sqe := ring.GetSQE()
-	if sqe == nil {
-		return
-	}
-	prepRecv(sqe, fd, buf)
-	setSQEUserData(sqe, encodeUserData(udRecv, fd))
-}
-
-func (t *midTier) PrepareSend(ring *Ring, fd int, buf []byte, linked bool) {
 	sqe := ring.GetSQE()
 	if sqe == nil {
 		return

--- a/engine/tier.go
+++ b/engine/tier.go
@@ -5,12 +5,20 @@ package engine
 type Tier uint8
 
 // io_uring capability tiers in ascending order of feature availability.
+//
+// The previous `Mid` tier (kernel 5.13–5.18) was retired in celeris
+// v1.4.8 because its only distinguishing feature (IORING_SETUP_COOP_TASKRUN)
+// was actually introduced in kernel 5.19, not 5.13 — pre-v1.4.8 every
+// 5.13–5.18 kernel (Ubuntu 22.04 LTS / 5.15 included) attempted
+// io_uring_setup with a flag the kernel rejects with -EINVAL, forcing a
+// noisy fall-back to Base. With the gate corrected, the 5.13–5.18 range
+// gains no capability over 5.10–5.12 and collapses into Base. See
+// celeris#287.
 const (
 	None     Tier = iota // no io_uring support
-	Base                 // kernel 5.10+
-	Mid                  // kernel 5.13+ (COOP_TASKRUN)
-	High                 // kernel 5.19+ (multishot accept/recv, provided buffers)
-	Optional             // kernel 6.0+ (SINGLE_ISSUER, SQPOLL)
+	Base                 // kernel 5.10+ (LTS-stable io_uring baseline; linked SQE chains, single-shot accept/recv)
+	High                 // kernel 5.19+ (multishot accept/recv, provided buffers, fixed files, COOP_TASKRUN, SINGLE_ISSUER)
+	Optional             // kernel 6.0+ (adds SQPOLL, SEND_ZC; 6.1+ swaps COOP_TASKRUN → DEFER_TASKRUN)
 )
 
 // String returns the tier name (e.g. "none", "base", "high").
@@ -20,8 +28,6 @@ func (t Tier) String() string {
 		return "none"
 	case Base:
 		return "base"
-	case Mid:
-		return "mid"
 	case High:
 		return "high"
 	case Optional:

--- a/engine/tier_test.go
+++ b/engine/tier_test.go
@@ -9,7 +9,6 @@ func TestTierString(t *testing.T) {
 	}{
 		{None, "none"},
 		{Base, "base"},
-		{Mid, "mid"},
 		{High, "high"},
 		{Optional, "optional"},
 		{Tier(255), "unknown"},
@@ -25,7 +24,7 @@ func TestTierAvailable(t *testing.T) {
 	if None.Available() {
 		t.Error("None.Available() = true, want false")
 	}
-	for _, tier := range []Tier{Base, Mid, High, Optional} {
+	for _, tier := range []Tier{Base, High, Optional} {
 		if !tier.Available() {
 			t.Errorf("%v.Available() = false, want true", tier)
 		}
@@ -33,7 +32,7 @@ func TestTierAvailable(t *testing.T) {
 }
 
 func TestTierOrdering(t *testing.T) {
-	ordered := []Tier{None, Base, Mid, High, Optional}
+	ordered := []Tier{None, Base, High, Optional}
 	for i := 0; i < len(ordered)-1; i++ {
 		if ordered[i] >= ordered[i+1] {
 			t.Errorf("expected %v < %v", ordered[i], ordered[i+1])

--- a/middleware/session/postgresstore/integration_test.go
+++ b/middleware/session/postgresstore/integration_test.go
@@ -119,3 +119,54 @@ func TestTruncateEmptyPrefix_Integration(t *testing.T) {
 		t.Fatal("TRUNCATE should remove all rows")
 	}
 }
+
+// TestEnsureSchema_ConcurrentRacers_Integration pins the v1.4.9 fix
+// for the postgresstore schema-init race surfaced by probatorium's
+// matrix nightly. Two driver_postgres refapps booting simultaneously
+// against the same PostgreSQL instance (msa2-server amd64 + msr1
+// arm64 in the cluster) each call New → ensureSchema. Pre-fix, the
+// loser hit SQLSTATE 23505 (unique violation on pg_type_typname_nsp_index)
+// because CREATE TABLE IF NOT EXISTS is not atomic at the catalog
+// level. Post-fix, pg_advisory_xact_lock serializes them.
+//
+// Concurrency factor 8 generates enough collision pressure that the
+// pre-fix code reliably failed within a few iterations.
+func TestEnsureSchema_ConcurrentRacers_Integration(t *testing.T) {
+	dsn := os.Getenv("CELERIS_PG_DSN")
+	if dsn == "" {
+		t.Skip("CELERIS_PG_DSN unset; skipping integration test")
+	}
+	pool, err := postgres.Open(dsn)
+	if err != nil {
+		t.Fatalf("postgres.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = pool.Close() })
+
+	// All racers target the SAME table — that's the race surface.
+	table := fmt.Sprintf("celeris_sessions_race_%d", time.Now().UnixNano())
+	t.Cleanup(func() {
+		_, _ = pool.ExecContext(context.Background(),
+			fmt.Sprintf("DROP TABLE IF EXISTS %s", table))
+	})
+
+	const racers = 8
+	errCh := make(chan error, racers)
+	startCh := make(chan struct{})
+	for i := 0; i < racers; i++ {
+		go func() {
+			<-startCh
+			_, err := New(context.Background(), pool, Options{
+				TableName:       table,
+				CleanupInterval: 0, // disable cleanup goroutine — we only care about schema init
+			})
+			errCh <- err
+		}()
+	}
+	close(startCh) // release all racers simultaneously
+
+	for i := 0; i < racers; i++ {
+		if err := <-errCh; err != nil {
+			t.Errorf("racer %d: %v", i, err)
+		}
+	}
+}

--- a/middleware/session/postgresstore/postgresstore.go
+++ b/middleware/session/postgresstore/postgresstore.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"sync"
 	"time"
 
@@ -126,7 +127,42 @@ func New(ctx context.Context, pool *postgres.Pool, opts ...Options) (*Store, err
 	return s, nil
 }
 
+// ensureSchema creates the sessions table and its supporting index if
+// they do not already exist.
+//
+// The DDL is wrapped in a transaction-scoped advisory lock
+// (pg_advisory_xact_lock) keyed on the table name. CREATE TABLE IF NOT
+// EXISTS is NOT atomic in PostgreSQL: the existence pre-check happens
+// outside the row-insertion path into pg_class/pg_type, so two
+// concurrent racers can both pass the "does it exist?" gate and then
+// race in the catalog. The loser surfaces SQLSTATE 23505 (unique
+// violation on pg_type_typname_nsp_index) — a class of failure
+// observed in the probatorium matrix nightly when both arch hosts
+// (amd64 + arm64) boot a driver_postgres refapp simultaneously against
+// the same PostgreSQL instance.
+//
+// The advisory key is derived from a 64-bit FNV-1a hash of
+// "postgresstore:ensureSchema:" + table name. Different tables get
+// different keys (no blocking between unrelated stores); the same
+// table always gets the same key (concurrent racers serialize). The
+// lock is released automatically at COMMIT/ROLLBACK.
 func (s *Store) ensureSchema(ctx context.Context) error {
+	tx, err := s.pool.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("postgresstore: ensure schema: begin tx: %w", err)
+	}
+	// Defer rollback for the error paths; a no-op after Commit succeeds.
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if _, err := tx.ExecContext(ctx, "SELECT pg_advisory_xact_lock($1)", advisoryLockKey(s.table)); err != nil {
+		return fmt.Errorf("postgresstore: ensure schema: acquire advisory lock: %w", err)
+	}
+
 	stmts := []string{
 		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
 			id TEXT PRIMARY KEY,
@@ -137,11 +173,29 @@ func (s *Store) ensureSchema(ctx context.Context) error {
 			ON %s (expires_at) WHERE expires_at IS NOT NULL`, s.table, s.table),
 	}
 	for _, q := range stmts {
-		if _, err := s.pool.ExecContext(ctx, q); err != nil {
+		if _, err := tx.ExecContext(ctx, q); err != nil {
 			return fmt.Errorf("postgresstore: ensure schema: %w", err)
 		}
 	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("postgresstore: ensure schema: commit: %w", err)
+	}
+	committed = true
 	return nil
+}
+
+// advisoryLockKey derives a stable int64 key for pg_advisory_xact_lock
+// from the target table name. FNV-1a/64 is a non-cryptographic hash;
+// collisions across unrelated table names are acceptable here — the
+// worst case is two stores serializing their schema-init unnecessarily,
+// not a correctness issue. The int64 cast preserves the bit pattern;
+// PostgreSQL accepts the full int64 range.
+func advisoryLockKey(table string) int64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte("postgresstore:ensureSchema:"))
+	_, _ = h.Write([]byte(table))
+	return int64(h.Sum64()) // #nosec G115 — intentional bitwise cast
 }
 
 // Close stops the cleanup goroutine. Safe to call multiple times.

--- a/middleware/session/postgresstore/postgresstore_test.go
+++ b/middleware/session/postgresstore/postgresstore_test.go
@@ -55,3 +55,35 @@ func TestNewRejectsBadTableName(t *testing.T) {
 		t.Fatal("New with invalid table name should error")
 	}
 }
+
+// TestAdvisoryLockKey_DeterministicPerTable pins the contract that
+// advisoryLockKey is stable across calls for the same table (so two
+// racers serialize on the same lock) and differs between tables (so
+// unrelated stores don't block each other unnecessarily). Underpins
+// the ensureSchema race fix.
+func TestAdvisoryLockKey_DeterministicPerTable(t *testing.T) {
+	tables := []string{
+		"celeris_sessions",
+		"celeris_sessions",
+		"other_sessions",
+		"yet_another",
+	}
+	keys := make(map[string]int64)
+	for _, tbl := range tables {
+		keys[tbl] = advisoryLockKey(tbl)
+	}
+	if keys["celeris_sessions"] == 0 {
+		t.Fatal("advisoryLockKey returned zero — improbable, suggests broken hash")
+	}
+	if keys["celeris_sessions"] != advisoryLockKey("celeris_sessions") {
+		t.Fatal("advisoryLockKey must be stable for the same input")
+	}
+	if keys["celeris_sessions"] == keys["other_sessions"] {
+		t.Errorf("advisoryLockKey collision: %q and %q both → %d",
+			"celeris_sessions", "other_sessions", keys["celeris_sessions"])
+	}
+	if keys["other_sessions"] == keys["yet_another"] {
+		t.Errorf("advisoryLockKey collision: %q and %q both → %d",
+			"other_sessions", "yet_another", keys["other_sessions"])
+	}
+}

--- a/probe/probe.go
+++ b/probe/probe.go
@@ -26,7 +26,10 @@ func parseTierName(s string) engine.Tier {
 	case "high":
 		return engine.High
 	case "mid":
-		return engine.Mid
+		// Backwards-compat alias: the `Mid` tier was retired in v1.4.8
+		// (see celeris#287). Map any existing CELERIS_MAX_IOURING_TIER=mid
+		// configuration to Base so deployed manifests don't break.
+		return engine.Base
 	case "base":
 		return engine.Base
 	default:
@@ -43,7 +46,9 @@ func capIOUringTier(p engine.CapabilityProfile, maxTier engine.Tier) engine.Capa
 	if maxTier < engine.Optional {
 		p.SQPoll = false
 		p.SendZC = false
-		p.SingleIssuer = false
+		// SingleIssuer is cleared in the `maxTier < High` branch below
+		// — it landed in 5.19 (High) alongside COOP_TASKRUN, not in 6.0
+		// (Optional). See celeris#287.
 	}
 	if maxTier < engine.High {
 		p.MultishotAccept = false
@@ -51,9 +56,12 @@ func capIOUringTier(p engine.CapabilityProfile, maxTier engine.Tier) engine.Capa
 		p.ProvidedBuffers = false
 		p.FixedFiles = false
 		p.DeferTaskrun = false
-	}
-	if maxTier < engine.Mid {
+		// COOP_TASKRUN + SINGLE_ISSUER were introduced together in 5.19
+		// and land at the High tier (see celeris#287). Pre-fix the Mid
+		// tier owned CoopTaskrun at 5.13; that was wrong, the flag did
+		// not exist before 5.19.
 		p.CoopTaskrun = false
+		p.SingleIssuer = false
 	}
 	if maxTier < engine.Base {
 		p.LinkedSQEs = false
@@ -89,6 +97,13 @@ func ProbeWith(sp *SyscallProber) engine.CapabilityProfile { //nolint:revive // 
 		profile.EpollAvailable = sp.ProbeEpoll()
 	}
 
+	// 5.10 is celeris's LTS-stable io_uring floor. The io_uring syscall
+	// itself landed in 5.1, but pre-5.10 kernels carry pre-LTS-stability
+	// io_uring bugs (deadlocks, credential races, registered-fd surprises)
+	// that are not worth supporting in a production HTTP engine. 5.10 is
+	// the cut-off: Debian 11, RHEL 8.5+, and every distro since carry
+	// 5.10+. Kernels below 5.10 fall through to the epoll path above.
+	// See celeris#287 Finding 3.
 	if kv.AtLeast(5, 10) && sp.ProbeIOUring != nil {
 		features, ops, err := sp.ProbeIOUring()
 		if err == nil {

--- a/probe/probe_test.go
+++ b/probe/probe_test.go
@@ -8,14 +8,25 @@ import (
 	"github.com/goceleris/celeris/engine"
 )
 
+// mockProber returns a SyscallProber that reports all IORING_FEAT_*
+// bits present. The default mock is for tests that don't care about
+// the vendor-kernel cross-check (Finding 4); for tests that want to
+// exercise the suspect-vendor path, use mockProberWithFeatures.
 func mockProber(kernelVersion string, ioUringErr error, epoll bool, capSysNice bool, numaNodes int) *SyscallProber {
+	return mockProberWithFeatures(kernelVersion, 0xFFFFFFFF, ioUringErr, epoll, capSysNice, numaNodes)
+}
+
+// mockProberWithFeatures lets the caller pin the IORING_FEAT_* bitmap.
+// Tests for the cross-check at probe/tier.go:determineTier use this to
+// simulate a vendor / backport kernel with diverged feature surface.
+func mockProberWithFeatures(kernelVersion string, features uint32, ioUringErr error, epoll bool, capSysNice bool, numaNodes int) *SyscallProber {
 	return &SyscallProber{
 		ReadKernelVersion: func() (string, error) { return kernelVersion, nil },
 		ProbeIOUring: func() (uint32, []uint8, error) {
 			if ioUringErr != nil {
 				return 0, nil, ioUringErr
 			}
-			return 0, nil, nil
+			return features, nil, nil
 		},
 		ProbeEpoll:      func() bool { return epoll },
 		CheckCapSysNice: func() bool { return capSysNice },
@@ -99,8 +110,10 @@ func TestProbeWithHighTier(t *testing.T) {
 	if profile.DeferTaskrun {
 		t.Fatal("expected no DeferTaskrun on kernel 5.19")
 	}
-	if profile.SingleIssuer {
-		t.Fatal("expected no SingleIssuer")
+	if !profile.SingleIssuer {
+		// SINGLE_ISSUER landed in 5.19 alongside COOP_TASKRUN — see
+		// celeris#287 Finding 1 / Finding 2 and io_uring_setup(2).
+		t.Fatal("expected SingleIssuer on 5.19")
 	}
 	if profile.SQPoll {
 		t.Fatal("expected no SQPoll")
@@ -110,18 +123,26 @@ func TestProbeWithHighTier(t *testing.T) {
 	}
 }
 
-func TestProbeWithMidTier(t *testing.T) {
+// TestProbeWith5_13Through5_18 pins the v1.4.8 fix for celeris#287:
+// kernels in the 5.13–5.18 range no longer surface CoopTaskrun (the
+// IORING_SETUP_COOP_TASKRUN flag does not exist before 5.19). They now
+// land on Base tier; pre-v1.4.7 they incorrectly landed on Mid with
+// CoopTaskrun=true and caused a noisy fall-back when io_uring_setup
+// rejected the flag.
+func TestProbeWith5_13Through5_18(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("tier detection requires linux GOOS")
 	}
-	sp := mockProber("5.13.0", nil, true, false, 1)
+	// 5.13 with IORING_FEAT_RSRC_TAGS (1<<10) set, confirming a real
+	// 5.13+ kernel rather than a vendor backport.
+	sp := mockProberWithFeatures("5.13.0", 1<<10, nil, true, false, 1)
 	profile := ProbeWith(sp)
 
-	if profile.IOUringTier != engine.Mid {
-		t.Fatalf("expected Mid tier, got %s", profile.IOUringTier)
+	if profile.IOUringTier != engine.Base {
+		t.Fatalf("expected Base tier on 5.13 (Mid retired in v1.4.8), got %s", profile.IOUringTier)
 	}
-	if !profile.CoopTaskrun {
-		t.Fatal("expected CoopTaskrun")
+	if profile.CoopTaskrun {
+		t.Fatal("CoopTaskrun must be false on 5.13 — flag landed in 5.19")
 	}
 	if profile.ProvidedBuffers {
 		t.Fatal("expected no ProvidedBuffers")
@@ -134,6 +155,48 @@ func TestProbeWithMidTier(t *testing.T) {
 	}
 	if profile.DeferTaskrun {
 		t.Fatal("expected no DeferTaskrun on kernel 5.13")
+	}
+	if profile.SingleIssuer {
+		t.Fatal("expected no SingleIssuer on 5.13 — flag landed in 5.19")
+	}
+}
+
+// TestProbeWith5_15Ubuntu22_04 pins the production smoking gun that
+// motivated celeris#287: Ubuntu 22.04 LTS ships kernel 5.15. Pre-fix,
+// every Ubuntu 22.04 host attempted io_uring_setup with COOP_TASKRUN
+// (EINVAL) and fell back noisily.
+func TestProbeWith5_15Ubuntu22_04(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("tier detection requires linux GOOS")
+	}
+	sp := mockProberWithFeatures("5.15.0-generic", 1<<10, nil, true, false, 1)
+	profile := ProbeWith(sp)
+	if profile.IOUringTier != engine.Base {
+		t.Fatalf("Ubuntu 22.04 (5.15) must land on Base, got %s", profile.IOUringTier)
+	}
+	if profile.CoopTaskrun {
+		t.Fatal("Ubuntu 22.04 must not advertise CoopTaskrun (kernel 5.15, flag at 5.19)")
+	}
+}
+
+// TestProbeWithSuspectVendorKernel exercises the Finding 4 defence:
+// a kernel that claims via uname to be ≥ 5.13 but doesn't report
+// IORING_FEAT_RSRC_TAGS in its features bitmap is clamped to Base.
+// This guards against forked / backported kernels whose feature surface
+// diverges from the upstream version table.
+func TestProbeWithSuspectVendorKernel(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("tier detection requires linux GOOS")
+	}
+	// 6.0 kernel claim but features=0 (no RSRC_TAGS) — treat as vendor
+	// kernel with diverged surface.
+	sp := mockProberWithFeatures("6.0.0", 0, nil, true, false, 1)
+	profile := ProbeWith(sp)
+	if profile.IOUringTier != engine.Base {
+		t.Fatalf("suspect vendor kernel (claims 6.0, lacks RSRC_TAGS bit) must clamp to Base, got %s", profile.IOUringTier)
+	}
+	if profile.CoopTaskrun || profile.SingleIssuer || profile.SQPoll {
+		t.Fatal("suspect vendor kernel must not surface 5.19+/6.0+ flags")
 	}
 }
 

--- a/probe/tier.go
+++ b/probe/tier.go
@@ -2,35 +2,109 @@ package probe
 
 import "github.com/goceleris/celeris/engine"
 
-func determineTier(kv KernelVersion, _ uint32, _ []uint8) (tier engine.Tier, multishotAccept, multishotRecv, providedBuffers, sqpoll, coopTaskrun, singleIssuer, linkedSQEs, deferTaskrun, fixedFiles, sendZC bool) {
+// IORING_FEAT_* bits from include/uapi/linux/io_uring.h. Reported via
+// the `features` field returned by io_uring_setup(2) — defence-in-depth
+// cross-check so a forked / vendor-backported kernel doesn't get gated
+// purely on the major.minor pair from `uname`.
+//
+// We only check the feature bits we depend on; the broader set is
+// documented for diagnostics but unused at the gate. Values match the
+// kernel headers exactly.
+const (
+	iouringFeatRsrcTags = 1 << 10 // since 5.13 — sentinel for "real 5.13+ kernel"
+	iouringFeatCQESkip  = 1 << 11 // since 5.17 — used to suppress success CQEs (unused at gate; reserved for future cross-check)
+)
+
+// determineTier maps a parsed kernel version + the IORING_FEAT_* bits
+// reported by io_uring_setup(2)'s sentinel call to a celeris [engine.Tier]
+// and the per-feature flags the engine consults. `ops` is the
+// IORING_REGISTER_PROBE op support bitmap; reserved for a future
+// op-availability cross-check (celeris#287 Finding 4) and ignored
+// for now.
+//
+// Gate-by-gate rationale (all flag/feature versions confirmed against
+// io_uring_setup(2) man-page + LWN merge-window articles — see the
+// references in celeris#287):
+//
+//   - 5.10 floor:  the io_uring syscall itself landed in 5.1, but
+//     pre-5.10 kernels are non-LTS-stable for io_uring (deadlocks,
+//     credential races, registered-fd bugs). 5.10 is the LTS-stable
+//     cut-off: Debian 11, RHEL 8.5+, and every distro since carry
+//     5.10+. Anything older falls back to epoll.
+//   - 5.19 SETUP_COOP_TASKRUN:  the flag did not exist before 5.19.
+//     Pre-fix (celeris ≤ v1.4.7), the gate was 5.13, which made every
+//     5.13–5.18 kernel (Ubuntu 22.04 LTS / 5.15 included) attempt
+//     io_uring_setup with a flag the kernel rejects with -EINVAL,
+//     forcing a noisy fall-back to Base. With the gate at 5.19, the
+//     5.13–5.18 range simply uses Base without the failed setup probe.
+//   - 5.19 SETUP_SINGLE_ISSUER:  landed in 5.19 alongside COOP_TASKRUN
+//     and the multishot / provided-buffer set; treated as one
+//     capability tier (High).
+//   - 6.0 SETUP_SQPOLL:  the SQPOLL flag itself has been in io_uring
+//     since 5.1 (unprivileged from 5.13), but Celeris-supported SQPOLL
+//     means SQPOLL ∧ SINGLE_ISSUER — the lock-free SQ batching path
+//     that's actually been benchmarked. SQPOLL on its own (without
+//     SINGLE_ISSUER) gives a more modest gain not worth the kernel-
+//     thread CPU overhead, and unprivileged SQPOLL in the 5.13–5.x
+//     range has been the source of several upstream CVE backports.
+//     Bundling SQPOLL into the 6.0+ Optional tier keeps the supported
+//     configuration sharp.
+//   - 6.0 SEND_ZC:  the IORING_OP_SEND_ZC opcode landed in 6.0.
+//   - 6.1 SETUP_DEFER_TASKRUN:  landed in 6.1; replaces COOP_TASKRUN
+//     in the setup flags on the High and Optional tiers.
+//
+// Tier topology:
+//
+//	None     — kernel < 5.10 or io_uring probe failed (engine falls back to epoll).
+//	Base     — 5.10 ≤ kernel < 5.19. Linked-SQE chains, single-shot
+//	           accept/recv. No COOP_TASKRUN.
+//	High     — 5.19 ≤ kernel < 6.0. Adds multishot accept/recv, provided
+//	           buffers, fixed files, COOP_TASKRUN, SINGLE_ISSUER.
+//	Optional — kernel ≥ 6.0. Adds SQPOLL and SEND_ZC. With kernel ≥ 6.1,
+//	           DEFER_TASKRUN replaces COOP_TASKRUN in setup flags.
+//
+// Note: the previous `engine.Mid` tier (5.13–5.18) was retired in
+// celeris v1.4.8 — its only distinguishing feature (COOP_TASKRUN) was
+// version-gated incorrectly. With the gate corrected, the 5.13–5.18
+// range carries no additional capability over 5.10–5.12, so the tier
+// collapses into Base. See celeris#287.
+func determineTier(kv KernelVersion, features uint32, _ []uint8) (tier engine.Tier, multishotAccept, multishotRecv, providedBuffers, sqpoll, coopTaskrun, singleIssuer, linkedSQEs, deferTaskrun, fixedFiles, sendZC bool) {
 	if !kv.AtLeast(5, 10) {
 		return engine.None, false, false, false, false, false, false, false, false, false, false
 	}
 
+	// Defence-in-depth: a real ≥ 5.13 kernel reports IORING_FEAT_RSRC_TAGS
+	// in `features`. If the kernel claims via uname to be ≥ 5.13 but the
+	// bit is missing, treat it as a vendor / forked kernel whose feature
+	// surface diverges from the upstream version table and clamp to Base.
+	// Conservative — the engine's runtime probe at NewRing time will
+	// validate every actually-requested flag anyway, so the worst case
+	// is a one-tier downgrade with a clear diagnostic. Issue #287
+	// Finding 4.
+	versionClaimsAtLeast513 := kv.AtLeast(5, 13)
+	featuresConfirmAtLeast513 := features&iouringFeatRsrcTags != 0
+	suspectVendorKernel := versionClaimsAtLeast513 && !featuresConfirmAtLeast513
+
 	tier = engine.Base
 	linkedSQEs = true
 
-	if kv.AtLeast(5, 13) {
-		tier = engine.Mid
-		coopTaskrun = true
-	}
-
-	if kv.AtLeast(5, 19) {
+	if kv.AtLeast(5, 19) && !suspectVendorKernel {
 		tier = engine.High
 		multishotAccept = true
 		multishotRecv = true
 		providedBuffers = true
 		fixedFiles = true
+		coopTaskrun = true
+		singleIssuer = true
 	}
 
-	if kv.AtLeast(6, 0) {
+	if kv.AtLeast(6, 0) && !suspectVendorKernel {
 		tier = engine.Optional
-		singleIssuer = true
 		sqpoll = true
 		sendZC = true
 	}
 
-	if kv.AtLeast(6, 1) {
+	if kv.AtLeast(6, 1) && !suspectVendorKernel {
 		deferTaskrun = true
 	}
 


### PR DESCRIPTION
## Summary

Six findings from #287, all applied surgically. The headline:

> `IORING_SETUP_COOP_TASKRUN` was version-gated at kernel 5.13 — the flag was actually introduced in 5.19. Pre-fix, every 5.13–5.18 kernel (Ubuntu 22.04 LTS / 5.15, Amazon Linux 2023, RHEL 9 baseline, …) attempted `io_uring_setup` with a flag the kernel rejects with `-EINVAL`, forcing a noisy fall-back to Base.

The `Mid` tier had `COOP_TASKRUN` as its only distinguishing feature; with the gate corrected, the 5.13–5.18 range gains nothing over 5.10–5.12 and the tier collapses into Base.

### Findings addressed

| # | Finding | Status |
|---|---|---|
| 1 | BUG: `IORING_SETUP_COOP_TASKRUN` gate 5.13 → 5.19 | ✓ fixed in `probe/tier.go` |
| 2 | Design: SQPOLL bundled at 6.0 with SINGLE_ISSUER+SEND_ZC | ✓ kept, documented inline (`probe/tier.go` doc comment) |
| 3 | Design: Base floor at 5.10 vs flag at 5.1 | ✓ kept, LTS-stability rationale documented (`probe/probe.go`) |
| 4 | Latent: `determineTier` discards probed feature bits | ✓ wires `IORING_FEAT_RSRC_TAGS` sentinel cross-check |
| 5 | Tests pin the broken mapping | ✓ updated; +2 new tests for the Finding 4 cross-check |
| 6 | `Mid` tier topology if Finding 1 is fixed | ✓ option (a): retired (`engine.Mid` removed) |

### Topology change

```
Before                                  After
None     (kernel < 5.10)                None     (kernel < 5.10)
Base     (5.10–5.12)                    Base     (5.10–5.18)
Mid      (5.13–5.18) ← buggy            High     (5.19+)
High     (5.19+)                        Optional (6.0+)
Optional (6.0+)
```

- `engine.Tier` enum loses `Mid` (4 → 3 tiers).
- `engine/iouring/SelectTier` loses the `Mid` case.
- `midTier` struct + 8 methods deleted from `engine/iouring/tier.go`.
- `fallbackTier` (in `engine/iouring/engine.go`) reroutes `highTier → baseTier` (was `highTier → midTier → baseTier`).
- `parseTierName(\"mid\")` keeps a Base-tier alias for back-compat with `CELERIS_MAX_IOURING_TIER=mid` deployments.

### Defence-in-depth: feature-bitmap cross-check

`determineTier` now consumes the `features` bitmap returned by `io_uring_setup(2)`. `IORING_FEAT_RSRC_TAGS` (since 5.13) is checked as a sentinel: a kernel that claims via `uname` to be ≥ 5.13 but doesn't report the bit is treated as a forked / vendor-backported kernel with diverged feature surface and clamped to Base. The engine's runtime probe at `NewRing` time validates every actually-requested flag anyway, so the worst case is a one-tier downgrade with a clear diagnostic.

### Companion change

`SDD/SDD.md` Appendix B updated in lockstep (separate commit in the SDD repo: `goceleris/SDD@f3e7237`).

### Test plan

- [x] `go build ./...` clean (linux + native)
- [x] `go vet ./...` clean (linux + native)
- [x] `golangci-lint run ./probe/... ./engine/` — 0 issues
- [x] `go test ./...` — full celeris suite green (60+ packages)
- [x] New tests cover: 5.13–5.18 → Base, Ubuntu 22.04 (5.15) → Base, suspect-vendor-kernel clamp, 5.19 + SingleIssuer assertion
- [ ] Probatorium nightly post-merge (v1.4.8 re-tag follow-up)