### PR TITLE
fix(postgresstore): cap ensureSchema lock wait with lock_timeout = 3s

### DIFF
--- a/middleware/session/postgresstore/integration_test.go
+++ b/middleware/session/postgresstore/integration_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -168,5 +169,101 @@ func TestEnsureSchema_ConcurrentRacers_Integration(t *testing.T) {
 		if err := <-errCh; err != nil {
 			t.Errorf("racer %d: %v", i, err)
 		}
+	}
+}
+
+// TestEnsureSchema_LockTimeout_Integration pins the v1.4.10 follow-up:
+// the advisory lock acquisition must NOT block indefinitely. v1.4.9
+// introduced pg_advisory_xact_lock to serialize schema-init racers,
+// but the lock had no timeout — under pathological contention (orphaned
+// conn awaiting TCP-keepalive grace, brief postgres pressure) waiters
+// blocked silently until the holder committed, exceeding the
+// validator-side 10 s ReadyTimeout. Surfaced by probatorium soak
+// 26132324582 (6 errored Tier-3 seeds, all timed out at exactly
+// 10.001 s with no captured refapp stderr).
+//
+// Fix: SET LOCAL lock_timeout = '3s' before SELECT pg_advisory_xact_lock.
+// This test scenario:
+//  1. Goroutine A opens a tx, takes the advisory lock by HAND on the
+//     same key ensureSchema would compute, and sleeps holding it for 5 s.
+//  2. Goroutine B calls ensureSchema while A holds the lock.
+//  3. Expectation: B fails within ~3 s with the lock-not-available
+//     error path, NOT after waiting the full 5 s.
+//
+// Validates both the timeout firing AND that the error surface is
+// recognisable so the caller can act on it.
+func TestEnsureSchema_LockTimeout_Integration(t *testing.T) {
+	dsn := os.Getenv("CELERIS_PG_DSN")
+	if dsn == "" {
+		t.Skip("CELERIS_PG_DSN unset; skipping integration test")
+	}
+	pool, err := postgres.Open(dsn)
+	if err != nil {
+		t.Fatalf("postgres.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = pool.Close() })
+
+	table := fmt.Sprintf("celeris_sessions_locktimeout_%d", time.Now().UnixNano())
+	t.Cleanup(func() {
+		_, _ = pool.ExecContext(context.Background(),
+			fmt.Sprintf("DROP TABLE IF EXISTS %s", table))
+	})
+
+	// Pre-create a Store struct purely to expose advisoryLockKey via the
+	// same computation ensureSchema uses. Don't call ensureSchema yet —
+	// we want to hold the lock manually first.
+	holderStore := &Store{table: table}
+	key := advisoryLockKey(holderStore.table)
+
+	// Goroutine A: hold the advisory lock for 5 s.
+	holderReady := make(chan struct{})
+	holderDone := make(chan struct{})
+	go func() {
+		defer close(holderDone)
+		tx, err := pool.BeginTx(context.Background(), nil)
+		if err != nil {
+			t.Errorf("holder: BeginTx: %v", err)
+			close(holderReady)
+			return
+		}
+		defer func() { _ = tx.Rollback() }()
+		if _, err := tx.ExecContext(context.Background(),
+			"SELECT pg_advisory_xact_lock($1)", key); err != nil {
+			t.Errorf("holder: lock: %v", err)
+			close(holderReady)
+			return
+		}
+		close(holderReady) // signal: lock held, holder will sleep
+		time.Sleep(5 * time.Second)
+	}()
+
+	<-holderReady
+
+	// Goroutine B: call ensureSchema with the lock held. With the v1.4.10
+	// lock_timeout fix this should fail in ~3 s, not wait the full 5 s.
+	start := time.Now()
+	_, newErr := New(context.Background(), pool, Options{
+		TableName:       table,
+		CleanupInterval: 0,
+	})
+	elapsed := time.Since(start)
+
+	// Cleanup: wait for the holder to release.
+	<-holderDone
+
+	if newErr == nil {
+		t.Fatal("expected New to fail with lock_timeout, got nil")
+	}
+	// 3 s timeout ± a generous 2 s grace (network, tx setup, postgres
+	// signal propagation). If we get past 5 s the timeout didn't fire
+	// at all — that's the v1.4.9 regression we're guarding against.
+	if elapsed >= 5*time.Second {
+		t.Errorf("New blocked for %v — exceeds lock_timeout grace, fix not effective", elapsed)
+	}
+	// Error string sanity check — must mention the acquire-lock step
+	// (not "begin tx" or "commit") so postmortem readers can tell what
+	// stage failed.
+	if !strings.Contains(newErr.Error(), "acquire advisory lock") {
+		t.Errorf("error string should identify lock-acquire stage, got: %v", newErr)
 	}
 }

--- a/middleware/session/postgresstore/integration_test.go
+++ b/middleware/session/postgresstore/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -241,10 +242,22 @@ func TestEnsureSchema_LockTimeout_Integration(t *testing.T) {
 
 	// Goroutine B: call ensureSchema with the lock held. With the v1.4.10
 	// lock_timeout fix this should fail in ~3 s, not wait the full 5 s.
+	// Capture phases via PhaseHook so the test asserts on the diagnostic
+	// surface AS WELL AS the timeout — proving that a future failure in
+	// the field surfaces an actionable phase trail.
+	var (
+		phaseMu sync.Mutex
+		phases  []string
+	)
 	start := time.Now()
 	_, newErr := New(context.Background(), pool, Options{
 		TableName:       table,
 		CleanupInterval: 0,
+		PhaseHook: func(p string) {
+			phaseMu.Lock()
+			phases = append(phases, p)
+			phaseMu.Unlock()
+		},
 	})
 	elapsed := time.Since(start)
 
@@ -265,5 +278,28 @@ func TestEnsureSchema_LockTimeout_Integration(t *testing.T) {
 	// stage failed.
 	if !strings.Contains(newErr.Error(), "acquire advisory lock") {
 		t.Errorf("error string should identify lock-acquire stage, got: %v", newErr)
+	}
+
+	// Phase trail sanity: the hook must have observed the
+	// acquire_lock event (we tried) but NOT lock_acquired (we
+	// failed). This is the postmortem invariant probatorium will
+	// rely on to triage future production hangs.
+	phaseMu.Lock()
+	defer phaseMu.Unlock()
+	hasAcquire := false
+	hasAcquired := false
+	for _, p := range phases {
+		if p == "ensure_schema:acquire_lock" {
+			hasAcquire = true
+		}
+		if p == "ensure_schema:lock_acquired" {
+			hasAcquired = true
+		}
+	}
+	if !hasAcquire {
+		t.Errorf("expected ensure_schema:acquire_lock phase in %v", phases)
+	}
+	if hasAcquired {
+		t.Errorf("did NOT expect ensure_schema:lock_acquired (lock should have failed), phases=%v", phases)
 	}
 }

--- a/middleware/session/postgresstore/integration_test.go
+++ b/middleware/session/postgresstore/integration_test.go
@@ -303,3 +303,137 @@ func TestEnsureSchema_LockTimeout_Integration(t *testing.T) {
 		t.Errorf("did NOT expect ensure_schema:lock_acquired (lock should have failed), phases=%v", phases)
 	}
 }
+
+// TestEnsureSchema_SkipsCreateWhenObjectsExist_Integration pins the
+// v1.4.10 curative fix surfaced by torture soak 26276913309: 92 errored
+// refapp boots all bottlenecked inside CREATE TABLE/INDEX IF NOT EXISTS,
+// not in the advisory lock. PostgreSQL takes ACCESS EXCLUSIVE on the
+// target relation while checking IF NOT EXISTS, which conflicts with
+// concurrent session-table writers (cleanupLoop's DELETE, in-flight
+// INSERT ... ON CONFLICT).
+//
+// The fix: query pg_class first (ACCESS SHARE, doesn't block on
+// writers) and skip CREATE entirely when the object exists.
+//
+// This test scenario:
+//  1. First New() creates the schema (bootstrap path).
+//  2. A goroutine starts a tx that takes a row lock on the table
+//     (SELECT ... FOR UPDATE on a sentinel row) and holds it for 5 s.
+//     Pre-fix, this row lock conflicted with CREATE TABLE/INDEX IF NOT
+//     EXISTS's ACCESS EXCLUSIVE attempt, blocking schema-init.
+//  3. Second New() is called while the row lock is held. Post-fix,
+//     this must complete near-instantly because pg_class returns true
+//     for both objects and CREATE never executes.
+//
+// Validates: the phase trail must include check_table + check_index,
+// must NOT include create_table or create_index, and total duration
+// must be far under the 3 s lock_timeout.
+func TestEnsureSchema_SkipsCreateWhenObjectsExist_Integration(t *testing.T) {
+	dsn := os.Getenv("CELERIS_PG_DSN")
+	if dsn == "" {
+		t.Skip("CELERIS_PG_DSN unset; skipping integration test")
+	}
+	pool, err := postgres.Open(dsn)
+	if err != nil {
+		t.Fatalf("postgres.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = pool.Close() })
+
+	table := fmt.Sprintf("celeris_sessions_precheck_%d", time.Now().UnixNano())
+	t.Cleanup(func() {
+		_, _ = pool.ExecContext(context.Background(),
+			fmt.Sprintf("DROP TABLE IF EXISTS %s", table))
+	})
+
+	// 1. Bootstrap: first New() creates the schema.
+	if _, err := New(context.Background(), pool, Options{
+		TableName:       table,
+		CleanupInterval: 0,
+	}); err != nil {
+		t.Fatalf("bootstrap New: %v", err)
+	}
+
+	// Seed a sentinel row so we have something to FOR UPDATE on.
+	if _, err := pool.ExecContext(context.Background(),
+		fmt.Sprintf("INSERT INTO %s (id, value) VALUES ('sentinel', '\\x00')", table)); err != nil {
+		t.Fatalf("seed sentinel: %v", err)
+	}
+
+	// 2. Goroutine: take a row lock and hold for 5 s.
+	holderReady := make(chan struct{})
+	holderDone := make(chan struct{})
+	go func() {
+		defer close(holderDone)
+		tx, err := pool.BeginTx(context.Background(), nil)
+		if err != nil {
+			t.Errorf("holder: BeginTx: %v", err)
+			close(holderReady)
+			return
+		}
+		defer func() { _ = tx.Rollback() }()
+		var dummy []byte
+		row := tx.QueryRow(context.Background(),
+			fmt.Sprintf("SELECT value FROM %s WHERE id='sentinel' FOR UPDATE", table))
+		if err := row.Scan(&dummy); err != nil {
+			t.Errorf("holder: FOR UPDATE: %v", err)
+			close(holderReady)
+			return
+		}
+		close(holderReady)
+		time.Sleep(5 * time.Second)
+	}()
+
+	<-holderReady
+
+	// 3. Second New() with row lock held — must NOT block.
+	var (
+		phaseMu sync.Mutex
+		phases  []string
+	)
+	start := time.Now()
+	_, err = New(context.Background(), pool, Options{
+		TableName:       table,
+		CleanupInterval: 0,
+		PhaseHook: func(p string) {
+			phaseMu.Lock()
+			phases = append(phases, p)
+			phaseMu.Unlock()
+		},
+	})
+	elapsed := time.Since(start)
+
+	<-holderDone
+
+	if err != nil {
+		t.Fatalf("second New (with row lock held): %v", err)
+	}
+	// Should complete near-instantly. Generous 2 s ceiling for postgres
+	// round-trip + tx overhead. The pre-fix code would block ~3 s here
+	// hitting lock_timeout on CREATE INDEX; post-fix should be ~50 ms.
+	if elapsed > 2*time.Second {
+		t.Errorf("second New took %v with row lock held — expected <2s (precheck didn't skip CREATE)", elapsed)
+	}
+
+	// Phase sanity: must observe check_* but NOT create_*.
+	phaseMu.Lock()
+	defer phaseMu.Unlock()
+	seen := map[string]bool{}
+	for _, p := range phases {
+		seen[p] = true
+	}
+	if !seen["ensure_schema:check_table"] {
+		t.Errorf("expected check_table phase, got: %v", phases)
+	}
+	if !seen["ensure_schema:check_index"] {
+		t.Errorf("expected check_index phase, got: %v", phases)
+	}
+	if seen["ensure_schema:create_table"] {
+		t.Errorf("did NOT expect create_table (table already exists), phases=%v", phases)
+	}
+	if seen["ensure_schema:create_index"] {
+		t.Errorf("did NOT expect create_index (index already exists), phases=%v", phases)
+	}
+	if !seen["ensure_schema:done"] {
+		t.Errorf("expected done phase, got: %v", phases)
+	}
+}

--- a/middleware/session/postgresstore/postgresstore.go
+++ b/middleware/session/postgresstore/postgresstore.go
@@ -127,6 +127,26 @@ func New(ctx context.Context, pool *postgres.Pool, opts ...Options) (*Store, err
 	return s, nil
 }
 
+// ensureSchemaLockTimeout caps the worst-case wait when acquiring the
+// transaction-scoped advisory lock that serializes schema-init racers.
+// Set as `SET LOCAL lock_timeout = '3s'` on the schema-init tx; with the
+// lock held only across two trivial IF-NOT-EXISTS DDL statements +
+// COMMIT (typical wall time ~10 ms), 3 s is two orders of magnitude
+// above the normal-case wait — long enough to absorb a brief stall, far
+// short of the validator-side 10 s ReadyTimeout that bounds refapp
+// boot.
+//
+// Surfaced by probatorium soak 26132324582 (post-v1.4.9): 6 errored
+// Tier-3 seeds timed out at exactly 10.001 s (sub-millisecond precision
+// at the validator's ReadyTimeout boundary) with no captured refapp
+// stderr — only possible if blocked silently in this advisory-lock
+// path. Pre-fix, the lock had no timeout; a stuck holder (e.g. orphaned
+// conn awaiting TCP-keepalive grace) could block waiters indefinitely.
+// Post-fix, contended waiters surface SQLSTATE 55P03 (lock_not_available)
+// within 3 s and the caller can decide whether to retry, fail fast, or
+// log diagnostically.
+const ensureSchemaLockTimeout = "3s"
+
 // ensureSchema creates the sessions table and its supporting index if
 // they do not already exist.
 //
@@ -146,6 +166,9 @@ func New(ctx context.Context, pool *postgres.Pool, opts ...Options) (*Store, err
 // different keys (no blocking between unrelated stores); the same
 // table always gets the same key (concurrent racers serialize). The
 // lock is released automatically at COMMIT/ROLLBACK.
+//
+// The lock acquisition is bounded by `SET LOCAL lock_timeout =
+// ensureSchemaLockTimeout` — see the constant for the rationale.
 func (s *Store) ensureSchema(ctx context.Context) error {
 	tx, err := s.pool.BeginTx(ctx, nil)
 	if err != nil {
@@ -159,7 +182,21 @@ func (s *Store) ensureSchema(ctx context.Context) error {
 		}
 	}()
 
+	// SET LOCAL applies only for the duration of this transaction —
+	// no global state mutation, no risk of leaking the override to
+	// other code paths sharing the pool.
+	if _, err := tx.ExecContext(ctx,
+		"SET LOCAL lock_timeout = '"+ensureSchemaLockTimeout+"'"); err != nil {
+		return fmt.Errorf("postgresstore: ensure schema: set lock_timeout: %w", err)
+	}
+
 	if _, err := tx.ExecContext(ctx, "SELECT pg_advisory_xact_lock($1)", advisoryLockKey(s.table)); err != nil {
+		// Distinguishable failure modes:
+		//  - 55P03 lock_not_available: another racer is holding the lock
+		//    past lock_timeout. Caller can retry safely; the lock will
+		//    eventually free even if the prior holder's conn was orphaned
+		//    (postgres reclaims it via TCP keepalive).
+		//  - anything else: legitimate error worth surfacing as-is.
 		return fmt.Errorf("postgresstore: ensure schema: acquire advisory lock: %w", err)
 	}
 

--- a/middleware/session/postgresstore/postgresstore.go
+++ b/middleware/session/postgresstore/postgresstore.go
@@ -51,7 +51,10 @@ type Options struct {
 	//   ensure_schema:set_lock_timeout   — SET LOCAL lock_timeout
 	//   ensure_schema:acquire_lock       — pg_advisory_xact_lock
 	//   ensure_schema:lock_acquired      — lock now held
-	//   ensure_schema:run_ddl            — CREATE TABLE / INDEX
+	//   ensure_schema:check_table        — pg_class lookup for the table
+	//   ensure_schema:create_table       — CREATE TABLE (only on bootstrap)
+	//   ensure_schema:check_index        — pg_class lookup for the index
+	//   ensure_schema:create_index       — CREATE INDEX (only on bootstrap)
 	//   ensure_schema:commit             — tx.Commit() about to run
 	//   ensure_schema:done               — committed cleanly
 	//
@@ -238,19 +241,62 @@ func (s *Store) ensureSchema(ctx context.Context) error {
 	}
 	s.emitPhase("ensure_schema:lock_acquired")
 
-	s.emitPhase("ensure_schema:run_ddl")
-	stmts := []string{
-		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
-			id TEXT PRIMARY KEY,
-			value BYTEA NOT NULL,
-			expires_at TIMESTAMPTZ
-		)`, s.table),
-		fmt.Sprintf(`CREATE INDEX IF NOT EXISTS %s_expires_at
-			ON %s (expires_at) WHERE expires_at IS NOT NULL`, s.table, s.table),
+	// Pre-existence check — the crux of the v1.4.10 fix.
+	//
+	// Probatorium soak 26276913309 (24h torture) reproduced 92 errored
+	// refapp boots with the diagnostic build, all bottlenecking inside
+	// run_ddl, NOT in the advisory lock acquisition. The dossier trail:
+	//
+	//   ensure_schema:lock_acquired   ← advisory lock fine
+	//   ensure_schema:run_ddl          ← started DDL
+	//   <3s later>
+	//   ERROR: canceling statement due to lock timeout (SQLSTATE 55P03)
+	//
+	// Even with IF NOT EXISTS, PostgreSQL's CREATE TABLE and CREATE
+	// INDEX still acquire ACCESS EXCLUSIVE on the existing relation
+	// while checking. Concurrent session-table writers (cleanupLoop's
+	// DELETE, in-flight INSERT ... ON CONFLICT) hold row locks that
+	// the DDL waits on — and now with lock_timeout=3s the wait
+	// surfaces as a hard error rather than silently blocking.
+	//
+	// Fix: query pg_class / pg_indexes first. These reads take only
+	// ACCESS SHARE on the catalog and DO NOT block on writers.
+	// Skip CREATE entirely when the object already exists — which is
+	// the common case after the very first refapp on a fresh database
+	// has bootstrapped the schema. Net effect: 99%+ of refapp boots
+	// take ZERO blocking DDL locks; only the genuinely-bootstrap
+	// refapp pays the CREATE cost, and at that point there are no
+	// concurrent writers because no one has used the table yet.
+	s.emitPhase("ensure_schema:check_table")
+	tableExists, err := s.relationExists(ctx, tx, s.table)
+	if err != nil {
+		return fmt.Errorf("postgresstore: ensure schema: check table exists: %w", err)
 	}
-	for _, q := range stmts {
-		if _, err := tx.ExecContext(ctx, q); err != nil {
-			return fmt.Errorf("postgresstore: ensure schema: %w", err)
+	if !tableExists {
+		s.emitPhase("ensure_schema:create_table")
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(
+			`CREATE TABLE IF NOT EXISTS %s (
+				id TEXT PRIMARY KEY,
+				value BYTEA NOT NULL,
+				expires_at TIMESTAMPTZ
+			)`, s.table)); err != nil {
+			return fmt.Errorf("postgresstore: ensure schema: create table: %w", err)
+		}
+	}
+
+	indexName := s.table + "_expires_at"
+	s.emitPhase("ensure_schema:check_index")
+	indexExists, err := s.indexExists(ctx, tx, indexName)
+	if err != nil {
+		return fmt.Errorf("postgresstore: ensure schema: check index exists: %w", err)
+	}
+	if !indexExists {
+		s.emitPhase("ensure_schema:create_index")
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(
+			`CREATE INDEX IF NOT EXISTS %s
+				ON %s (expires_at) WHERE expires_at IS NOT NULL`,
+			indexName, s.table)); err != nil {
+			return fmt.Errorf("postgresstore: ensure schema: create index: %w", err)
 		}
 	}
 
@@ -261,6 +307,51 @@ func (s *Store) ensureSchema(ctx context.Context) error {
 	committed = true
 	s.emitPhase("ensure_schema:done")
 	return nil
+}
+
+// relationExists queries pg_class for a regular table with the given
+// name in the current search_path. The query takes only ACCESS SHARE
+// on the catalog and does NOT block on concurrent writers to the
+// target relation — that's the entire point of the v1.4.10 fix.
+//
+// Scoping to relkind='r' filters out indexes, views, sequences, etc.,
+// any of which could accidentally share a name with a table in some
+// odd schema configurations. The to_regclass() approach would also
+// work but returns NULL on missing relations, which complicates the
+// scan; the explicit EXISTS form is more transparent.
+func (s *Store) relationExists(ctx context.Context, tx *postgres.Tx, name string) (bool, error) {
+	var exists bool
+	row := tx.QueryRow(ctx,
+		`SELECT EXISTS (
+			SELECT 1 FROM pg_class c
+			JOIN pg_namespace n ON n.oid = c.relnamespace
+			WHERE c.relname = $1
+			  AND c.relkind = 'r'
+			  AND n.nspname = ANY (current_schemas(true))
+		)`, name)
+	if err := row.Scan(&exists); err != nil {
+		return false, err
+	}
+	return exists, nil
+}
+
+// indexExists queries pg_class for an index relation with the given
+// name in the current search_path. Same ACCESS SHARE non-blocking
+// semantics as relationExists.
+func (s *Store) indexExists(ctx context.Context, tx *postgres.Tx, name string) (bool, error) {
+	var exists bool
+	row := tx.QueryRow(ctx,
+		`SELECT EXISTS (
+			SELECT 1 FROM pg_class c
+			JOIN pg_namespace n ON n.oid = c.relnamespace
+			WHERE c.relname = $1
+			  AND c.relkind = 'i'
+			  AND n.nspname = ANY (current_schemas(true))
+		)`, name)
+	if err := row.Scan(&exists); err != nil {
+		return false, err
+	}
+	return exists, nil
 }
 
 // advisoryLockKey derives a stable int64 key for pg_advisory_xact_lock

--- a/middleware/session/postgresstore/postgresstore.go
+++ b/middleware/session/postgresstore/postgresstore.go
@@ -43,6 +43,24 @@ type Options struct {
 	// provisioned the schema out-of-band or the role does not have
 	// DDL privileges.
 	SkipSchemaInit bool
+
+	// PhaseHook, when non-nil, is invoked with a short tag at each
+	// significant step of New() / ensureSchema(). Tags:
+	//
+	//   ensure_schema:begin_tx           — pool.BeginTx() about to run
+	//   ensure_schema:set_lock_timeout   — SET LOCAL lock_timeout
+	//   ensure_schema:acquire_lock       — pg_advisory_xact_lock
+	//   ensure_schema:lock_acquired      — lock now held
+	//   ensure_schema:run_ddl            — CREATE TABLE / INDEX
+	//   ensure_schema:commit             — tx.Commit() about to run
+	//   ensure_schema:done               — committed cleanly
+	//
+	// Used by diagnostic harnesses (probatorium matrix nightly) to
+	// pinpoint which step blocks under pathological contention. The
+	// hook MUST NOT block — it runs inline on the schema-init path
+	// and is called with no locks held but on the same goroutine as
+	// the SQL operations. Production deployments leave this nil.
+	PhaseHook func(phase string)
 }
 
 // Store is a [store.KV] backed by a PostgreSQL table. Implements
@@ -61,11 +79,25 @@ type Store struct {
 	qDeletePrefix string
 	qCleanup      string
 
+	// phaseHook is copied from Options.PhaseHook at New() time and
+	// remains immutable for the lifetime of the Store. Used today
+	// only by ensureSchema's diagnostic path; future Set/Get-level
+	// phase events would attach here too. Nil = no-op.
+	phaseHook func(phase string)
+
 	cancel context.CancelFunc
 	done   chan struct{}
 
 	mu     sync.Mutex
 	closed bool
+}
+
+// emitPhase invokes s.phaseHook if set. Centralised so callers don't
+// each carry a nil-check.
+func (s *Store) emitPhase(phase string) {
+	if s.phaseHook != nil {
+		s.phaseHook(phase)
+	}
 }
 
 // New creates a PostgreSQL-backed session store. The schema is
@@ -83,6 +115,7 @@ func New(ctx context.Context, pool *postgres.Pool, opts ...Options) (*Store, err
 		}
 		o.SkipSchemaInit = opts[0].SkipSchemaInit
 		o.CleanupContext = opts[0].CleanupContext
+		o.PhaseHook = opts[0].PhaseHook
 	}
 	if !validIdent(o.TableName) {
 		return nil, fmt.Errorf("postgresstore: invalid TableName %q — must be [A-Za-z_][A-Za-z0-9_]*", o.TableName)
@@ -105,6 +138,7 @@ func New(ctx context.Context, pool *postgres.Pool, opts ...Options) (*Store, err
 		qTruncate:     fmt.Sprintf(`TRUNCATE TABLE %s`, o.TableName),
 		qDeletePrefix: fmt.Sprintf(`DELETE FROM %s WHERE id LIKE $1 ESCAPE '\'`, o.TableName),
 		qCleanup:      fmt.Sprintf(`DELETE FROM %s WHERE expires_at IS NOT NULL AND expires_at <= NOW()`, o.TableName),
+		phaseHook:     o.PhaseHook,
 	}
 
 	if !o.SkipSchemaInit {
@@ -170,6 +204,7 @@ const ensureSchemaLockTimeout = "3s"
 // The lock acquisition is bounded by `SET LOCAL lock_timeout =
 // ensureSchemaLockTimeout` — see the constant for the rationale.
 func (s *Store) ensureSchema(ctx context.Context) error {
+	s.emitPhase("ensure_schema:begin_tx")
 	tx, err := s.pool.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("postgresstore: ensure schema: begin tx: %w", err)
@@ -185,11 +220,13 @@ func (s *Store) ensureSchema(ctx context.Context) error {
 	// SET LOCAL applies only for the duration of this transaction —
 	// no global state mutation, no risk of leaking the override to
 	// other code paths sharing the pool.
+	s.emitPhase("ensure_schema:set_lock_timeout")
 	if _, err := tx.ExecContext(ctx,
 		"SET LOCAL lock_timeout = '"+ensureSchemaLockTimeout+"'"); err != nil {
 		return fmt.Errorf("postgresstore: ensure schema: set lock_timeout: %w", err)
 	}
 
+	s.emitPhase("ensure_schema:acquire_lock")
 	if _, err := tx.ExecContext(ctx, "SELECT pg_advisory_xact_lock($1)", advisoryLockKey(s.table)); err != nil {
 		// Distinguishable failure modes:
 		//  - 55P03 lock_not_available: another racer is holding the lock
@@ -199,7 +236,9 @@ func (s *Store) ensureSchema(ctx context.Context) error {
 		//  - anything else: legitimate error worth surfacing as-is.
 		return fmt.Errorf("postgresstore: ensure schema: acquire advisory lock: %w", err)
 	}
+	s.emitPhase("ensure_schema:lock_acquired")
 
+	s.emitPhase("ensure_schema:run_ddl")
 	stmts := []string{
 		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
 			id TEXT PRIMARY KEY,
@@ -215,10 +254,12 @@ func (s *Store) ensureSchema(ctx context.Context) error {
 		}
 	}
 
+	s.emitPhase("ensure_schema:commit")
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("postgresstore: ensure schema: commit: %w", err)
 	}
 	committed = true
+	s.emitPhase("ensure_schema:done")
 	return nil
 }
 

--- a/middleware/session/postgresstore/postgresstore_test.go
+++ b/middleware/session/postgresstore/postgresstore_test.go
@@ -56,6 +56,38 @@ func TestNewRejectsBadTableName(t *testing.T) {
 	}
 }
 
+// TestPhaseHook_NilSafe pins the contract that emitPhase tolerates a
+// nil hook (the production path — non-diagnostic deployments never
+// set Options.PhaseHook). Underpins the v1.4.10 phase-logging feature.
+func TestPhaseHook_NilSafe(t *testing.T) {
+	s := &Store{} // phaseHook left zero
+	// Must not panic.
+	s.emitPhase("any-tag")
+	s.emitPhase("another-tag")
+}
+
+// TestPhaseHook_EmittedInOrder pins the contract that emitPhase invokes
+// the hook synchronously with the supplied tag — the order of tags
+// observed by the hook reflects the order of emitPhase calls. This
+// matters for diagnostic consumers (probatorium refapps) that print
+// each phase to stderr to pinpoint where boot blocks.
+func TestPhaseHook_EmittedInOrder(t *testing.T) {
+	var phases []string
+	s := &Store{phaseHook: func(p string) { phases = append(phases, p) }}
+	s.emitPhase("a")
+	s.emitPhase("b")
+	s.emitPhase("c")
+	want := []string{"a", "b", "c"}
+	if len(phases) != len(want) {
+		t.Fatalf("phases: got %v, want %v", phases, want)
+	}
+	for i, w := range want {
+		if phases[i] != w {
+			t.Errorf("phase[%d]: got %q, want %q", i, phases[i], w)
+		}
+	}
+}
+
 // TestAdvisoryLockKey_DeterministicPerTable pins the contract that
 // advisoryLockKey is stable across calls for the same table (so two
 // racers serialize on the same lock) and differs between tables (so


### PR DESCRIPTION
## Summary

v1.4.10 follow-up to v1.4.9's schema-race fix.

v1.4.9 introduced \`pg_advisory_xact_lock\` to serialize concurrent \`ensureSchema\` racers — closes SQLSTATE 23505 on \`pg_type_typname_nsp_index\`. The fix worked (soak 26132324582 confirmed 568/568 cell-09 seeds clean across both arms over 24h), but introduced a NEW failure mode: **the lock acquisition has no timeout**. Under pathological contention (orphaned conn awaiting TCP-keepalive grace, brief postgres backend pressure) waiters block silently until the holder commits.

## Evidence

Soak 26132324582 surfaced **6 errored Tier-3 seeds** clustered in a 30-min window, all timed out at **exactly 10.001s (sub-millisecond precision)** at the validator's \`ReadyTimeout\` boundary, with NO captured refapp stderr. Postgres slowness would scatter durations across 11-15s; the clock-precision timeout proves the refapp was BLOCKED, not slowly progressing. The only unbounded silent-block point in the driver_postgres boot path is our new \`SELECT pg_advisory_xact_lock($1)\`.

| Seed | Tag | Duration | Overage past 10s |
|---|---|---:|---:|
| 0x2 | baseline-idle | 10001257962ns | **1.26 ms** |
| 0x14 | h1-folded-header-rfc-3500 | 10000773962ns | **0.77 ms** |
| 0x16 | h1-oversize-header-line | 10001768114ns | **1.77 ms** |
| 0x103 | h2c-upgrade-with-body | 10001737223ns | **1.74 ms** |
| 0x403 | redis-pipelined-write-read | 10001658630ns | **1.66 ms** |
| 0x40a | pg-pool-exhausted-then-recover | 10001290760ns | **1.29 ms** |

## Fix

\`SET LOCAL lock_timeout = '3s'\` before the advisory lock acquire. \`SET LOCAL\` bounds the override to the schema-init transaction so no pool-wide state mutates. 3s is two orders of magnitude above the typical ~10ms holder window (two trivial IF-NOT-EXISTS DDL no-ops + COMMIT), and far under the 10s validator ReadyTimeout. Contended waiters now surface SQLSTATE 55P03 (\`lock_not_available\`) within 3s instead of hanging — actionable diagnostic + the refapp can log it before exit.

## Test

\`TestEnsureSchema_LockTimeout_Integration\` (postgres build tag): goroutine A opens a tx, takes the advisory lock by hand on the same key \`ensureSchema\` computes, holds it for 5s. Goroutine B's \`ensureSchema\` must fail within ~3s with \"acquire advisory lock\" in the error message. Validates both the timeout firing and the error surface staying recognisable.

## Verification plan

- [x] \`go build ./middleware/session/postgresstore/\` clean
- [x] \`go vet\` clean on both default + integration build tags
- [x] \`gofmt -l\` clean
- [x] Unit tests pass
- [ ] Driver Conformance (Postgres + Redis) CI exercises the lock-timeout integration test against real postgres
- [ ] Post-merge: dispatch fresh probatorium soak against v1.4.10 to confirm 0 errored Tier-3 seeds