### PR TITLE
fix(engine): enforce ReadHeaderTimeout on iouring + epoll (proper cadence)

### DIFF
--- a/engine/epoll/loop.go
+++ b/engine/epoll/loop.go
@@ -417,10 +417,13 @@ func (l *Loop) run(ctx context.Context) {
 		// Check connection timeouts. Default cadence is every 1024 iterations
 		// (~100ms under load); when detached conns exist with idle deadlines
 		// the gate tightens to every 32 iterations (~50ms idle wall time)
-		// so the WS idle-close fires within its configured budget.
+		// so the WS idle-close fires within its configured budget. When
+		// ReadHeaderTimeout is enabled (the v1.4.11 slowloris defence),
+		// the gate ALSO tightens to 0x1F — see iouring/worker.go for the
+		// shared rationale.
 		l.tickCounter++
 		gate := uint32(0x3FF)
-		if l.detachedCount > 0 {
+		if l.detachedCount > 0 || l.cfg.ReadHeaderTimeout > 0 {
 			gate = 0x1F
 		}
 		if l.tickCounter&gate == 0 {
@@ -1509,6 +1512,13 @@ func (l *Loop) adaptiveTimeoutMs(base int) int {
 	maxMs := 500
 	if l.detachedCount > 0 {
 		maxMs = 50
+	}
+	// Slowloris defence: when ReadHeaderTimeout is enabled, cap the
+	// epoll_wait timeout so checkTimeouts can fire the HeaderDeadline
+	// reliably even under low traffic. 25ms * 0x1F gate = 800ms worst-
+	// case sweep latency, well below the walker's 2s drip-budget slack.
+	if l.cfg.ReadHeaderTimeout > 0 && maxMs > 25 {
+		maxMs = 25
 	}
 	switch {
 	case l.consecutiveEmpty == 0:

--- a/engine/epoll/loop.go
+++ b/engine/epoll/loop.go
@@ -890,6 +890,12 @@ func (l *Loop) initProtocol(cs *connState) {
 		cs.h1State.EnableH2Upgrade = l.cfg.EnableH2Upgrade
 		cs.h1State.WorkerID = int32(l.id)
 		cs.h1State.WorkerIDSet = true
+		// Slowloris defence: configure + arm the read-header deadline.
+		// ProcessH1 clears on successful parse and rearms on return-nil
+		// (waiting for next request); checkTimeouts closes any conn
+		// that exceeds the deadline.
+		cs.h1State.ReadHeaderTimeoutNs = int64(l.cfg.ReadHeaderTimeout)
+		cs.h1State.ArmHeaderDeadline()
 		if !l.cfg.EnableH2Upgrade {
 			cs.h1State.DisableH2CDetect()
 		}
@@ -1546,6 +1552,17 @@ func (l *Loop) checkTimeouts() {
 				l.closeConn(fd)
 			}
 			continue
+		}
+		// ReadHeaderTimeout: slowloris defence. Mirrors the iouring
+		// worker's checkTimeouts; pre-v1.4.11 this gate was missing
+		// on the epoll engine so the std-only doc claim was a lie.
+		// HeaderDeadlineNs is armed at conn-accept and after each
+		// successful request parse (see ProcessH1 in internal/conn).
+		if cs.h1State != nil {
+			if dl := cs.h1State.HeaderDeadlineNs.Load(); dl > 0 && now > dl {
+				l.closeConn(fd)
+				continue
+			}
 		}
 		elapsed := time.Duration(now - cs.lastActivity)
 		if cs.dirty {

--- a/engine/iouring/worker.go
+++ b/engine/iouring/worker.go
@@ -848,6 +848,12 @@ func (w *Worker) initProtocol(cs *connState) {
 		cs.h1State.EnableH2Upgrade = w.cfg.EnableH2Upgrade
 		cs.h1State.WorkerID = int32(w.id)
 		cs.h1State.WorkerIDSet = true
+		// Slowloris defence: arm the header read deadline so checkTimeouts
+		// closes any conn that fails to complete headers in time. ProcessH1
+		// clears it on successful parse; it rearms on return-nil
+		// (await-more-data) using ReadHeaderTimeoutNs stored here.
+		cs.h1State.ReadHeaderTimeoutNs = int64(w.cfg.ReadHeaderTimeout)
+		cs.h1State.ArmHeaderDeadline()
 		if !w.cfg.EnableH2Upgrade {
 			cs.h1State.DisableH2CDetect()
 		}
@@ -2557,6 +2563,20 @@ func (w *Worker) checkTimeouts() {
 				w.closeConn(fd)
 			}
 			continue
+		}
+		// ReadHeaderTimeout: slowloris defence. Set by the engine on
+		// fresh conns and after each successful request parse — cleared
+		// when ProcessH1 finishes a request. A non-zero value past the
+		// deadline means the peer is dripping headers slowly: close.
+		// Pre-v1.4.11 this check was missing on iouring/epoll; only the
+		// std engine honored ReadHeaderTimeout. Probatorium soak
+		// 26363052652 surfaced 1,910 adv_hang events distributed across
+		// iouring + epoll cells that had this gap.
+		if cs.h1State != nil {
+			if dl := cs.h1State.HeaderDeadlineNs.Load(); dl > 0 && now > dl {
+				w.closeConn(fd)
+				continue
+			}
 		}
 		elapsed := time.Duration(now - cs.lastActivity)
 		if cs.dirty || cs.sending {

--- a/engine/iouring/worker.go
+++ b/engine/iouring/worker.go
@@ -597,10 +597,18 @@ func (w *Worker) run(ctx context.Context) {
 		// iterations (~100ms under load); when detached conns exist with
 		// idle deadlines the gate tightens to every 32 iterations
 		// (~50ms idle wall time) so the WS idle-close fires within its
-		// configured budget.
+		// configured budget. When ReadHeaderTimeout is enabled (default
+		// 10s in config), the gate ALSO tightens to 0x1F so the
+		// slowloris-defence deadline fires within its expected budget
+		// even under low CQE traffic — surfaced by probatorium nightly
+		// 26366632586, where the prior 0x3FF gate combined with the
+		// 100ms adaptive wait cap could delay checkTimeouts by 100+
+		// seconds on under-utilised workers, letting slow-drip clients
+		// bypass the deadline. The v1.4.11 slowloris defence is only
+		// bulletproof with this tighter cadence.
 		w.tickCounter++
 		gate := uint32(0x3FF)
-		if w.detachedCount > 0 {
+		if w.detachedCount > 0 || w.cfg.ReadHeaderTimeout > 0 {
 			gate = 0x1F
 		}
 		if w.tickCounter&gate == 0 {
@@ -677,6 +685,15 @@ func (w *Worker) adaptiveTimeout() time.Duration {
 	maxWait := 100 * time.Millisecond
 	if w.detachedCount > 0 {
 		maxWait = 50 * time.Millisecond
+	}
+	// Slowloris defence: when ReadHeaderTimeout is enabled, the
+	// checkTimeouts cadence has a wall-time ceiling of maxWait * gate.
+	// To keep the worst-case sweep latency under 1s (well below the
+	// walker's 2s drip-budget slack), cap maxWait at 25ms when the
+	// header timeout is configured. Combined with the 0x1F gate (32
+	// iters): 25ms * 32 = 800ms worst case.
+	if w.cfg.ReadHeaderTimeout > 0 && maxWait > 25*time.Millisecond {
+		maxWait = 25 * time.Millisecond
 	}
 	switch {
 	case w.emptyIters <= 10:

--- a/internal/conn/h1.go
+++ b/internal/conn/h1.go
@@ -38,13 +38,25 @@ func (s *H1State) ClearHeaderDeadline() {
 	s.HeaderDeadlineNs.Store(0)
 }
 
-// ArmHeaderDeadline rearms the slowloris-defence read-header deadline
-// to now + ReadHeaderTimeoutNs. Called by ProcessH1 when transitioning
-// from request-complete back to await-next-request state, and by the
-// engine at conn accept. No-op if ReadHeaderTimeoutNs == 0 (config
-// disabled or std-engine compat mode).
+// ArmHeaderDeadline arms the slowloris-defence read-header deadline
+// to now + ReadHeaderTimeoutNs. Called by:
+//   - the engine at conn accept (covers "client never sends a byte"),
+//   - ProcessH1 when it observes data arriving on a conn whose deadline
+//     was cleared (post-handler-idle keep-alive state).
+//
+// Idempotent: if HeaderDeadlineNs is already non-zero, this is a no-op
+// — the deadline is an ABSOLUTE budget for header completion, NOT
+// per-read. Resetting on every read would let a slow-drip client
+// extend the budget indefinitely (the bug this fix is meant to defeat).
+//
+// No-op if ReadHeaderTimeoutNs == 0 (config disabled or std-engine
+// compat mode).
 func (s *H1State) ArmHeaderDeadline() {
 	if s.ReadHeaderTimeoutNs == 0 {
+		return
+	}
+	if s.HeaderDeadlineNs.Load() != 0 {
+		// Already armed; don't reset (slowloris-bypass guard).
 		return
 	}
 	s.HeaderDeadlineNs.Store(timeNow().UnixNano() + s.ReadHeaderTimeoutNs)
@@ -309,21 +321,29 @@ func ProcessH1(ctx context.Context, data []byte, state *H1State, handler stream.
 		return nil
 	}
 
-	// Slowloris defence: clear the read-header deadline while we're
-	// actively parsing (we're not stuck waiting for headers). On
-	// return-nil (await more data) the deadline is rearmed for the
-	// next request — see the defer below. Errors / close / upgrade
-	// return paths intentionally leave the deadline cleared because
-	// the conn is about to be closed or handed off.
-	state.ClearHeaderDeadline()
-	defer func() {
-		if retErr == nil {
-			// ProcessH1 returns nil to signal "await more data". Arm
-			// the deadline so checkTimeouts closes a peer that drips
-			// bytes too slowly. No-op if ReadHeaderTimeout disabled.
-			state.ArmHeaderDeadline()
-		}
-	}()
+	// Slowloris defence — ReadHeaderTimeout state machine.
+	//
+	// Semantic: the deadline tracks the absolute time by which the
+	// current request's HEADERS must be fully received. It must NOT
+	// be confused with keep-alive idle (which IdleTimeout handles).
+	//
+	//   - conn-accept: engine arms once (covers "client never sends")
+	//   - ProcessH1 entry with data arriving on a request not yet in
+	//     body/parsed state, and deadline currently 0 (post-clear or
+	//     post-handler-idle): arm. Don't reset an already-armed
+	//     deadline — that would let a slow-drip client extend its
+	//     budget indefinitely.
+	//   - ParseRequest success (consumed > 0): clear. Body / handler /
+	//     keep-alive idle phases do NOT have a header deadline.
+	//
+	// Why entry-arm-if-zero (not entry-clear-then-defer-arm): the
+	// keep-alive idle window between requests must NOT count against
+	// ReadHeaderTimeout. With defer-arm, every successful request
+	// would re-arm the deadline; the next keep-alive idle conn would
+	// get killed at ReadHeaderTimeout instead of IdleTimeout.
+	if state.HeaderDeadlineNs.Load() == 0 && state.bodyNeeded == 0 && !state.Detached {
+		state.ArmHeaderDeadline()
+	}
 
 	// In-progress fixed-length body spanning multiple reads. Append into
 	// the dedicated bodyBuf (no state.buffer memcpy), then re-parse the
@@ -347,6 +367,9 @@ func ProcessH1(ctx context.Context, data []byte, state *H1State, handler stream.
 			writeErrorResponse(write, 400, "Bad Request")
 			return err
 		}
+		// Headers complete (this is a re-parse from buffer, so the
+		// original parse already succeeded — clear is idempotent).
+		state.ClearHeaderDeadline()
 		state.buffer.Reset()
 		bodyData := state.bodyBuf
 		if err := tryUpgradeH2C(state, bodyData, rest, write); err != nil {
@@ -386,6 +409,11 @@ func ProcessH1(ctx context.Context, data []byte, state *H1State, handler stream.
 				state.buffer.Write(data[offset:])
 				return nil
 			}
+			// Headers complete — clear the slowloris deadline. The
+			// body / handler / keep-alive idle that follow are NOT
+			// header-deadline-eligible. Re-arm happens at the next
+			// ProcessH1 entry that observes deadline == 0.
+			state.ClearHeaderDeadline()
 
 			bodyNeeded := int64(0)
 			if state.req.ChunkedEncoding {
@@ -506,6 +534,9 @@ func ProcessH1(ctx context.Context, data []byte, state *H1State, handler stream.
 		if consumed == 0 {
 			break
 		}
+		// Headers complete — clear the slowloris deadline. See the
+		// state-machine comment at the top of ProcessH1.
+		state.ClearHeaderDeadline()
 
 		bodyNeeded := int64(0)
 		if state.req.ChunkedEncoding {

--- a/internal/conn/h1.go
+++ b/internal/conn/h1.go
@@ -8,11 +8,16 @@ import (
 	"fmt"
 	"net"
 	"sync/atomic"
+	"time"
 
 	"github.com/goceleris/celeris/internal/ctxkit"
 	h1 "github.com/goceleris/celeris/protocol/h1"
 	"github.com/goceleris/celeris/protocol/h2/stream"
 )
+
+// timeNow is a package-level alias so tests can stub the clock when
+// exercising the read-header-deadline path. Production = time.Now.
+var timeNow = time.Now
 
 func init() {
 	// Wire the H1-package helpers so protocol/h2/stream can lazily
@@ -24,6 +29,26 @@ func init() {
 // ErrHijacked is returned by ProcessH1 when the connection was hijacked.
 // The engine must not close or reuse the FD after receiving this error.
 var ErrHijacked = errors.New("celeris: connection hijacked")
+
+// ClearHeaderDeadline drops the slowloris-defence read-header deadline
+// — called after a successful ParseRequest signals that the next state
+// is request handling, not header reading. The engine's checkTimeouts
+// sweep treats 0 as "no deadline" and skips the check.
+func (s *H1State) ClearHeaderDeadline() {
+	s.HeaderDeadlineNs.Store(0)
+}
+
+// ArmHeaderDeadline rearms the slowloris-defence read-header deadline
+// to now + ReadHeaderTimeoutNs. Called by ProcessH1 when transitioning
+// from request-complete back to await-next-request state, and by the
+// engine at conn accept. No-op if ReadHeaderTimeoutNs == 0 (config
+// disabled or std-engine compat mode).
+func (s *H1State) ArmHeaderDeadline() {
+	if s.ReadHeaderTimeoutNs == 0 {
+		return
+	}
+	s.HeaderDeadlineNs.Store(timeNow().UnixNano() + s.ReadHeaderTimeoutNs)
+}
 
 // errConnectionClose is returned when the client requests Connection: close.
 // Pre-allocated to avoid per-request fmt.Errorf allocation.
@@ -101,6 +126,26 @@ type H1State struct {
 	// the engine's idle sweep checks it on detached connections. 0 = no
 	// deadline.
 	IdleDeadlineNs atomic.Int64
+
+	// HeaderDeadlineNs holds the absolute deadline (Unix nanoseconds) by
+	// which the next request's headers must be fully received, or the
+	// engine must close the connection. This is the canonical slowloris
+	// defence on the iouring + epoll engines (std wires the equivalent
+	// via http.Server.ReadHeaderTimeout). Set by the engine at conn-
+	// accept and after each successful request parse (so the next
+	// pipelined / keep-alive request gets a fresh budget). Cleared when
+	// ProcessH1 returns having fully parsed a request. 0 = no deadline
+	// (e.g. -1 in config explicitly disables; ReadHeaderTimeout was
+	// otherwise unenforced on iouring + epoll prior to celeris v1.4.11).
+	HeaderDeadlineNs atomic.Int64
+
+	// ReadHeaderTimeoutNs is the configured ReadHeaderTimeout in
+	// nanoseconds, supplied by the engine at initProtocol. Used by
+	// ProcessH1 to re-arm HeaderDeadlineNs after each request parse —
+	// keeps the deadline logic local to where it matters (the parsing
+	// loop) without ProcessH1 needing access to the engine's *cfg.
+	// 0 = no header deadline (config disabled).
+	ReadHeaderTimeoutNs int64
 
 	// EnableH2Upgrade, when true, permits this connection to honor a
 	// valid RFC 7540 §3.2 h2c upgrade request. Set by the engine at
@@ -254,7 +299,7 @@ func CloseH1(state *H1State) {
 // ProcessH1 processes incoming H1 data, parsing requests and calling the handler.
 // The write callback is used to send response bytes back to the connection.
 func ProcessH1(ctx context.Context, data []byte, state *H1State, handler stream.Handler,
-	write func([]byte)) error {
+	write func([]byte)) (retErr error) {
 
 	// WebSocket upgrade: deliver raw bytes to the middleware goroutine
 	// instead of parsing as H1. The delivery callback writes to an io.Pipe
@@ -263,6 +308,22 @@ func ProcessH1(ctx context.Context, data []byte, state *H1State, handler stream.
 		state.WSDataDelivery(data)
 		return nil
 	}
+
+	// Slowloris defence: clear the read-header deadline while we're
+	// actively parsing (we're not stuck waiting for headers). On
+	// return-nil (await more data) the deadline is rearmed for the
+	// next request — see the defer below. Errors / close / upgrade
+	// return paths intentionally leave the deadline cleared because
+	// the conn is about to be closed or handed off.
+	state.ClearHeaderDeadline()
+	defer func() {
+		if retErr == nil {
+			// ProcessH1 returns nil to signal "await more data". Arm
+			// the deadline so checkTimeouts closes a peer that drips
+			// bytes too slowly. No-op if ReadHeaderTimeout disabled.
+			state.ArmHeaderDeadline()
+		}
+	}()
 
 	// In-progress fixed-length body spanning multiple reads. Append into
 	// the dedicated bodyBuf (no state.buffer memcpy), then re-parse the

--- a/internal/conn/h1_test.go
+++ b/internal/conn/h1_test.go
@@ -2,9 +2,64 @@ package conn
 
 import (
 	"testing"
+	"time"
 
 	"github.com/goceleris/celeris/protocol/h1"
 )
+
+// TestHeaderDeadline_ClearArmCycle pins the v1.4.11 slowloris-defence
+// state machine for iouring + epoll. Pre-fix neither engine enforced
+// ReadHeaderTimeout (only std did, via http.Server). The state machine:
+//
+//   1. Engine sets ReadHeaderTimeoutNs + ArmHeaderDeadline at conn-
+//      accept. HeaderDeadlineNs is now > 0.
+//   2. ProcessH1 calls ClearHeaderDeadline at its entry (we're
+//      actively parsing, not waiting). HeaderDeadlineNs == 0.
+//   3. ProcessH1's deferred ArmHeaderDeadline fires on return-nil
+//      (awaiting next request's bytes). HeaderDeadlineNs > 0 again.
+//   4. If ReadHeaderTimeoutNs is 0 (config disabled), all arm calls
+//      are no-ops.
+//
+// checkTimeouts in each engine closes the conn when now > deadline.
+func TestHeaderDeadline_ClearArmCycle(t *testing.T) {
+	s := NewH1State()
+	s.ReadHeaderTimeoutNs = int64(10 * time.Second)
+
+	// Arm — deadline should be ~10s in the future.
+	before := time.Now().UnixNano()
+	s.ArmHeaderDeadline()
+	after := time.Now().UnixNano()
+	dl := s.HeaderDeadlineNs.Load()
+	if dl < before+s.ReadHeaderTimeoutNs || dl > after+s.ReadHeaderTimeoutNs {
+		t.Errorf("ArmHeaderDeadline: dl=%d not in [%d, %d]",
+			dl, before+s.ReadHeaderTimeoutNs, after+s.ReadHeaderTimeoutNs)
+	}
+
+	// Clear — deadline should be 0.
+	s.ClearHeaderDeadline()
+	if dl := s.HeaderDeadlineNs.Load(); dl != 0 {
+		t.Errorf("ClearHeaderDeadline: dl=%d, want 0", dl)
+	}
+
+	// Re-arm — back to a future deadline.
+	s.ArmHeaderDeadline()
+	if dl := s.HeaderDeadlineNs.Load(); dl <= 0 {
+		t.Errorf("Re-ArmHeaderDeadline: dl=%d, want positive", dl)
+	}
+}
+
+// TestHeaderDeadline_DisabledNoArm verifies the no-op behaviour when
+// ReadHeaderTimeoutNs is 0 (config disabled via -1 or omitted on a
+// custom build that doesn't set a default). ArmHeaderDeadline must
+// leave HeaderDeadlineNs at 0 so checkTimeouts skips the check.
+func TestHeaderDeadline_DisabledNoArm(t *testing.T) {
+	s := NewH1State()
+	s.ReadHeaderTimeoutNs = 0 // disabled
+	s.ArmHeaderDeadline()
+	if dl := s.HeaderDeadlineNs.Load(); dl != 0 {
+		t.Errorf("ArmHeaderDeadline with disabled config must be no-op, got dl=%d", dl)
+	}
+}
 
 func TestH1StateMaxBodySize(t *testing.T) {
 	s := NewH1State()

--- a/internal/conn/h1_test.go
+++ b/internal/conn/h1_test.go
@@ -61,6 +61,61 @@ func TestHeaderDeadline_DisabledNoArm(t *testing.T) {
 	}
 }
 
+// TestHeaderDeadline_ArmIdempotent pins the slowloris-bypass guard:
+// calling ArmHeaderDeadline twice MUST NOT advance the deadline. The
+// budget is absolute (from "first byte arrives" to "headers complete"),
+// not per-read. Without this guard a slow-drip client could call into
+// the engine (re-trigger ProcessH1's entry-arm) every few hundred ms
+// and indefinitely extend the budget.
+func TestHeaderDeadline_ArmIdempotent(t *testing.T) {
+	s := NewH1State()
+	s.ReadHeaderTimeoutNs = int64(10 * time.Second)
+
+	s.ArmHeaderDeadline()
+	first := s.HeaderDeadlineNs.Load()
+	if first == 0 {
+		t.Fatal("first ArmHeaderDeadline must arm")
+	}
+
+	// Sleep a bit so re-arming would observably shift the deadline.
+	time.Sleep(20 * time.Millisecond)
+
+	s.ArmHeaderDeadline() // must be no-op while already armed
+	second := s.HeaderDeadlineNs.Load()
+	if second != first {
+		t.Errorf("re-arm without clear must NOT shift deadline: first=%d second=%d (drift=%dns)",
+			first, second, second-first)
+	}
+}
+
+// TestHeaderDeadline_KeepAliveIdleNotKilled is the regression test for
+// the subtle bug caught during the v1.4.11 implementation review: my
+// earlier "defer arm on return-nil" design would have re-armed the
+// deadline at the end of EVERY successful request. The conn then enters
+// keep-alive idle (waiting for the next request), and 10s later
+// checkTimeouts would close it — killing the conn at ReadHeaderTimeout
+// instead of IdleTimeout.
+//
+// Correct semantic: after ClearHeaderDeadline (called when headers are
+// parsed), the deadline stays 0 through body / handler / keep-alive
+// idle. It only re-arms when the NEXT request's first byte arrives
+// (ProcessH1 entry observes deadline == 0 and arms).
+//
+// This test simulates: arm → clear → simulate idle window → confirm
+// the deadline is still 0 (NOT something we'd push past).
+func TestHeaderDeadline_KeepAliveIdleNotKilled(t *testing.T) {
+	s := NewH1State()
+	s.ReadHeaderTimeoutNs = int64(10 * time.Second)
+
+	s.ArmHeaderDeadline() // conn-accept arm
+	s.ClearHeaderDeadline() // headers parsed
+	// Simulate keep-alive idle window. checkTimeouts sees deadline==0
+	// → skips the check. IdleTimeout takes over (different code path).
+	if dl := s.HeaderDeadlineNs.Load(); dl != 0 {
+		t.Errorf("after clear, keep-alive idle must observe deadline=0, got %d", dl)
+	}
+}
+
 func TestH1StateMaxBodySize(t *testing.T) {
 	s := NewH1State()
 

--- a/internal/conn/h1_test.go
+++ b/internal/conn/h1_test.go
@@ -11,14 +11,14 @@ import (
 // state machine for iouring + epoll. Pre-fix neither engine enforced
 // ReadHeaderTimeout (only std did, via http.Server). The state machine:
 //
-//   1. Engine sets ReadHeaderTimeoutNs + ArmHeaderDeadline at conn-
-//      accept. HeaderDeadlineNs is now > 0.
-//   2. ProcessH1 calls ClearHeaderDeadline at its entry (we're
-//      actively parsing, not waiting). HeaderDeadlineNs == 0.
-//   3. ProcessH1's deferred ArmHeaderDeadline fires on return-nil
-//      (awaiting next request's bytes). HeaderDeadlineNs > 0 again.
-//   4. If ReadHeaderTimeoutNs is 0 (config disabled), all arm calls
-//      are no-ops.
+//  1. Engine sets ReadHeaderTimeoutNs + ArmHeaderDeadline at conn-
+//     accept. HeaderDeadlineNs is now > 0.
+//  2. ProcessH1 calls ClearHeaderDeadline at its entry (we're
+//     actively parsing, not waiting). HeaderDeadlineNs == 0.
+//  3. ProcessH1's deferred ArmHeaderDeadline fires on return-nil
+//     (awaiting next request's bytes). HeaderDeadlineNs > 0 again.
+//  4. If ReadHeaderTimeoutNs is 0 (config disabled), all arm calls
+//     are no-ops.
 //
 // checkTimeouts in each engine closes the conn when now > deadline.
 func TestHeaderDeadline_ClearArmCycle(t *testing.T) {
@@ -107,7 +107,7 @@ func TestHeaderDeadline_KeepAliveIdleNotKilled(t *testing.T) {
 	s := NewH1State()
 	s.ReadHeaderTimeoutNs = int64(10 * time.Second)
 
-	s.ArmHeaderDeadline() // conn-accept arm
+	s.ArmHeaderDeadline()   // conn-accept arm
 	s.ClearHeaderDeadline() // headers parsed
 	// Simulate keep-alive idle window. checkTimeouts sees deadline==0
 	// → skips the check. IdleTimeout takes over (different code path).


### PR DESCRIPTION
## Summary

Replaces #292 (closed). v1.4.11 candidate. Adds ReadHeaderTimeout enforcement on iouring + epoll engines, with reliable kernel-bounded sweep cadence.

## What was wrong with #292

#292 implemented the H1State `HeaderDeadlineNs` + ProcessH1 state machine + checkTimeouts integration. All correct. **But** the sweep cadence was unreliable: the existing 0x3FF gate (every 1024 worker iterations) combined with the 100ms adaptive wait cap meant `checkTimeouts` could be delayed by 100+ seconds on under-utilised workers. Probatorium nightly 26366632586 confirmed only 45% reduction in `adv_hang_until_timeout` instead of the expected ~100%.

## What this PR adds (on top of #292's cherry-picked commits)

When `w.cfg.ReadHeaderTimeout > 0` (default 10s in config):
- iouring `tickCounter` gate: `0x3FF` → `0x1F` (32 iters instead of 1024)
- iouring `adaptiveTimeout` `maxWait`: 100ms → 25ms
- epoll `tickCounter` gate: same 0x3FF → 0x1F
- epoll `adaptiveTimeoutMs` `maxMs`: 500ms → 25ms

**Worst-case `checkTimeouts` cadence: 25ms × 32 = 800ms** — well under the slowloris walker's 2s drip-budget slack (10s `ReadHeaderTimeout` + 2s slack = 12s walker budget).

## Why iterative

Per the v1.4.11 strategy decision: ship the simpler sweep-tighten first. Re-verify with nightly + soak. If hangs drop to 0, ship. If still non-zero, escalate to per-conn `IORING_OP_TIMEOUT` SQEs (iouring) / per-worker recurring timerfd (epoll) as v1.4.12.

## Cost analysis

~30× more `checkTimeouts` calls under load. Each scan is O(maxFD) but cheap — fd lookup + atomic load per conn. For typical 1k-10k conn fleets, extra CPU is negligible vs the kernel-syscall overhead saved by larger gates. Under truly idle load, the worker still wakes every 25ms instead of 100ms — measurable but tiny CPU shift.

## Tests

All cherry-picked unit tests from #292 still pass:
- `TestHeaderDeadline_ClearArmCycle`
- `TestHeaderDeadline_DisabledNoArm`
- `TestHeaderDeadline_ArmIdempotent`
- `TestHeaderDeadline_KeepAliveIdleNotKilled`

Full \`go test ./...\` clean. \`GOOS=linux go build ./engine/iouring ./engine/epoll\` clean. \`go vet ./...\` clean. gofmt clean.

## Empirical verification path

Probatorium nightly soak against this branch's SHA. Expect:
- `adv_hang_until_timeout` on iouring + epoll cells → ~0 (matching std)
- `h2c_hang` unchanged (separate root cause — slow refapp response, not header timeout)
- No bug-oracle regression (`properties_failed`, `adv_wrong_accepted`, `h2c_crashed`, `seeds_*` all stay 0)

Will not propose v1.4.11 tag until soak comes back clean.

## Commits

- 65f70c4 fix(engine): enforce ReadHeaderTimeout on iouring + epoll (cherry-picked from #292)
- c86db41 fix(postgresstore): correct ReadHeaderTimeout state machine — entry-arm-if-zero, not defer-arm (cherry-picked from #292)
- bd949c7 fix(test): gofmt h1_test.go numbered-list spacing (cherry-picked from #292)
- bb1a278 fix(engine): tighten checkTimeouts cadence when ReadHeaderTimeout enabled (this PR)