### PR TITLE
fix(engine): per-conn IORING_OP_TIMEOUT for ReadHeaderTimeout (v1.4.11 candidate)

### DIFF
--- a/engine/epoll/conn.go
+++ b/engine/epoll/conn.go
@@ -123,6 +123,15 @@ type connState struct {
 	// loop's epoll_wait set). The flag is set by OnDetach and
 	// cleared by drainDetachQueue once the bookkeeping runs.
 	asyncDetachPending bool
+
+	// forceRSTClose is set by the slowloris-defence path (checkTimeouts'
+	// HeaderDeadline branch) to signal closeConn should skip the graceful
+	// Shutdown(SHUT_WR)+drainRecvBuffer dance and instead call close()
+	// directly — SO_LINGER {1, 0} (set by the caller before closeConn)
+	// then forces RST so the walker observes ECONNRESET on its next
+	// write regardless of TCP send-buffer state. Mirrors the iouring
+	// engine's same-named flag.
+	forceRSTClose bool
 }
 
 var connStatePool = sync.Pool{
@@ -178,6 +187,7 @@ func releaseConnState(cs *connState) {
 	cs.asyncClosed.Store(false)
 	cs.asyncDetachUnlocked = false
 	cs.asyncDetachPending = false
+	cs.forceRSTClose = false
 	cs.fd = 0
 	connStatePool.Put(cs)
 }

--- a/engine/epoll/loop.go
+++ b/engine/epoll/loop.go
@@ -1666,16 +1666,19 @@ func (l *Loop) closeConn(fd int) {
 	// H2 (GOAWAY / RST_STREAM flushing) and WS/SSE detach (middleware-
 	// queued close frames).
 	//
-	// forceRSTClose (slowloris-defence) ALSO takes the fast path: the
-	// caller already set SO_LINGER {1, 0}, so a plain close() RSTs.
-	// Skipping SHUT_WR is critical — without it the conn would enter
-	// FIN_WAIT_1 first and the linger semantics may not trigger RST
-	// on some kernels (the walker's drip writes would keep succeeding
-	// locally past the close).
+	// forceRSTClose (slowloris-defence): SHUT_RDWR + SO_LINGER {1,0} +
+	// close = guaranteed RST even when the receive buffer is fully
+	// drained (which it is for our event-loop, unlike std's
+	// http.Server). See iouring/worker.go finishCloseDetached for the
+	// detailed rationale.
 	fastClose := !detached && cs.protocol == engine.HTTP1 && cs.h1State != nil && !trulyDetached
-	if fastClose || cs.forceRSTClose {
+	switch {
+	case cs.forceRSTClose:
+		_ = unix.Shutdown(fd, unix.SHUT_RDWR)
 		_ = unix.Close(fd)
-	} else {
+	case fastClose:
+		_ = unix.Close(fd)
+	default:
 		_ = unix.Shutdown(fd, unix.SHUT_WR)
 		drainRecvBuffer(fd)
 		_ = unix.Close(fd)

--- a/engine/epoll/loop.go
+++ b/engine/epoll/loop.go
@@ -1709,15 +1709,13 @@ func (l *Loop) closeConn(fd int) {
 	// H2 (GOAWAY / RST_STREAM flushing) and WS/SSE detach (middleware-
 	// queued close frames).
 	//
-	// forceRSTClose (slowloris-defence): SHUT_RDWR + SO_LINGER {1,0} +
-	// close = guaranteed RST even when the receive buffer is fully
-	// drained (which it is for our event-loop, unlike std's
-	// http.Server). See iouring/worker.go finishCloseDetached for the
-	// detailed rationale.
+	// forceRSTClose (slowloris-defence): plain close() with the
+	// SO_LINGER {1, 0} the caller set. No SHUT_* before — sending
+	// FIN first transitions the conn to FIN_WAIT_1 where LINGER may
+	// no longer fire RST on the subsequent close.
 	fastClose := !detached && cs.protocol == engine.HTTP1 && cs.h1State != nil && !trulyDetached
 	switch {
 	case cs.forceRSTClose:
-		_ = unix.Shutdown(fd, unix.SHUT_RDWR)
 		_ = unix.Close(fd)
 	case fastClose:
 		_ = unix.Close(fd)

--- a/engine/epoll/loop.go
+++ b/engine/epoll/loop.go
@@ -417,10 +417,14 @@ func (l *Loop) run(ctx context.Context) {
 		// Check connection timeouts. Default cadence is every 1024 iterations
 		// (~100ms under load); when detached conns exist with idle deadlines
 		// the gate tightens to every 32 iterations (~50ms idle wall time)
-		// so the WS idle-close fires within its configured budget.
+		// so the WS idle-close fires within its configured budget. When
+		// ReadHeaderTimeout is enabled (the v1.4.11 slowloris defence),
+		// the gate ALSO tightens to 0x1F — the in-process synthetic
+		// reproducer (test/integration/slowloris_synthetic_test.go) showed
+		// epoll's HeaderDeadline firing 2s late without this.
 		l.tickCounter++
 		gate := uint32(0x3FF)
-		if l.detachedCount > 0 {
+		if l.detachedCount > 0 || l.cfg.ReadHeaderTimeout > 0 {
 			gate = 0x1F
 		}
 		if l.tickCounter&gate == 0 {
@@ -1509,6 +1513,12 @@ func (l *Loop) adaptiveTimeoutMs(base int) int {
 	maxMs := 500
 	if l.detachedCount > 0 {
 		maxMs = 50
+	}
+	// Slowloris defence: cap epoll_wait when ReadHeaderTimeout is enabled
+	// so checkTimeouts fires the HeaderDeadline reliably under low traffic.
+	// 25ms × 0x1F gate = 800ms worst-case sweep latency.
+	if l.cfg.ReadHeaderTimeout > 0 && maxMs > 25 {
+		maxMs = 25
 	}
 	switch {
 	case l.consecutiveEmpty == 0:

--- a/engine/epoll/loop.go
+++ b/engine/epoll/loop.go
@@ -1706,22 +1706,27 @@ func (l *Loop) closeConn(fd int) {
 		l.removeH2Conn(fd)
 	}
 	_ = unix.EpollCtl(l.epollFD, unix.EPOLL_CTL_DEL, fd, nil)
-	// Plain unix.Close for H1 connections (both sync and async-mode pre-
-	// allocated detachMu but not truly detached). Mirrors std/net.http
-	// c.close() → c.rwc.Close(): no shutdown, no linger, no drain. The
-	// shutdown+drain combo was leaving a ~5-7% walker-hang rate on
-	// probatorium slow-refapp slowloris cells (nightly 26429150655 et
-	// al), pointing at our extra syscalls racing with the peer's
-	// in-flight Write rather than at FIN/RST signaling per se.
+	// H1 close: SHUT_WR + Close. The shutdown call forces FIN regardless
+	// of the kernel recv-buffer state — important under slowloris where
+	// the peer is still writing drips and a plain Close on a non-empty
+	// recv buffer would send RST instead (which is not retransmitted by
+	// TCP, so a single packet loss strands the walker).
 	//
-	// Graceful path retained for H2 (GOAWAY / RST_STREAM flushing) and
-	// for truly detached WS/SSE conns (middleware-queued close frames).
+	// No drainRecvBuffer between SHUT_WR and Close: an empty drain leaves
+	// no race, but a non-empty one introduces a multi-µs window in which
+	// a fresh peer drip queues — then Close sees it and emits RST anyway.
+	// Just trust SHUT_WR's FIN to be retransmitted until ACK'd.
+	//
+	// Graceful drain path retained for H2 (GOAWAY / RST_STREAM flushing)
+	// and for truly detached WS/SSE conns (middleware-queued close
+	// frames).
 	plainClose := cs.h1State != nil && !trulyDetached && cs.h2State == nil
 	switch {
 	case cs.forceRSTClose:
 		_ = unix.Shutdown(fd, unix.SHUT_RDWR)
 		_ = unix.Close(fd)
 	case plainClose:
+		_ = unix.Shutdown(fd, unix.SHUT_WR)
 		_ = unix.Close(fd)
 	default:
 		_ = unix.Shutdown(fd, unix.SHUT_WR)

--- a/engine/epoll/loop.go
+++ b/engine/epoll/loop.go
@@ -1566,12 +1566,11 @@ func (l *Loop) checkTimeouts() {
 		// ReadHeaderTimeout: slowloris defence. Force RST close so the
 		// peer immediately observes termination on its next write —
 		// see iouring/worker.go handleHeaderTimer for the SO_LINGER {1,0}
-		// rationale. The fastClose path here is unchanged; we only flip
-		// the linger semantics for slowloris-triggered closes so the
-		// walker doesn't get fooled by TCP send-buffer hangover.
+		// + forceRSTClose rationale.
 		if cs.h1State != nil {
 			if dl := cs.h1State.HeaderDeadlineNs.Load(); dl > 0 && now > dl {
 				_ = unix.SetsockoptLinger(fd, unix.SOL_SOCKET, unix.SO_LINGER, &unix.Linger{Onoff: 1, Linger: 0})
+				cs.forceRSTClose = true
 				l.closeConn(fd)
 				continue
 			}
@@ -1666,8 +1665,15 @@ func (l *Loop) closeConn(fd int) {
 	// the Connection:close churn hot path. Graceful path retained for
 	// H2 (GOAWAY / RST_STREAM flushing) and WS/SSE detach (middleware-
 	// queued close frames).
+	//
+	// forceRSTClose (slowloris-defence) ALSO takes the fast path: the
+	// caller already set SO_LINGER {1, 0}, so a plain close() RSTs.
+	// Skipping SHUT_WR is critical — without it the conn would enter
+	// FIN_WAIT_1 first and the linger semantics may not trigger RST
+	// on some kernels (the walker's drip writes would keep succeeding
+	// locally past the close).
 	fastClose := !detached && cs.protocol == engine.HTTP1 && cs.h1State != nil && !trulyDetached
-	if fastClose {
+	if fastClose || cs.forceRSTClose {
 		_ = unix.Close(fd)
 	} else {
 		_ = unix.Shutdown(fd, unix.SHUT_WR)

--- a/engine/epoll/loop.go
+++ b/engine/epoll/loop.go
@@ -1588,6 +1588,18 @@ func (l *Loop) adaptiveTimeoutMs(base int) int {
 
 // checkTimeouts scans active connections and closes any that have exceeded
 // their configured timeout. Called every 1024 iterations (~100ms).
+// requestTimeoutResponse is the canonical HTTP/1.1 408 Request Timeout
+// response sent to slowloris clients before their conn is closed. Static
+// across calls; one allocation at package init. Content-Length: 0 keeps
+// the response to a single TCP segment (~80 bytes, well under MSS) so a
+// single unix.Write delivers it in one shot to the kernel send buffer.
+var requestTimeoutResponse = []byte(
+	"HTTP/1.1 408 Request Timeout\r\n" +
+		"Connection: close\r\n" +
+		"Content-Length: 0\r\n" +
+		"\r\n",
+)
+
 func (l *Loop) checkTimeouts() {
 	now := time.Now().UnixNano()
 	for fd := 0; fd <= l.maxFD; fd++ {
@@ -1606,14 +1618,30 @@ func (l *Loop) checkTimeouts() {
 			}
 			continue
 		}
-		// ReadHeaderTimeout: slowloris defence. Force RST close so the
-		// peer immediately observes termination on its next write —
-		// see iouring/worker.go handleHeaderTimer for the SO_LINGER {1,0}
-		// + forceRSTClose rationale.
+		// ReadHeaderTimeout: slowloris defence.
+		//
+		// Pre-fix: SHUT_RDWR + close + SO_LINGER{1,0} for RST. Empirically
+		// this left ~5-7% walker-side hangs on slow-refapp cells
+		// (observability + static_swagger_proxy) — FIN/RST visibility
+		// under cluster load is just unreliable enough that the walker's
+		// 20s drip-budget fires before its kernel observes the close on a
+		// small consistent fraction of attempts. Same shape on iouring +
+		// epoll despite their close paths being independent.
+		//
+		// Fix: write a 408 Request Timeout response synchronously via
+		// unix.Write (bytes hit the kernel send buffer immediately), then
+		// graceful-close via the default closeConn path. TCP retransmits
+		// response bytes if dropped → walker's Read returns 1 byte of
+		// response data → wellReject. No dependency on FIN/RST signaling.
+		//
+		// Sync write is fine on the event-loop thread: the response is
+		// ~80 bytes, well under MSS; the conn's send buffer is empty
+		// (server never wrote anything for slowloris) so EAGAIN is
+		// practically impossible. Even on partial write the walker
+		// observes the first byte and exits its drip loop.
 		if cs.h1State != nil {
 			if dl := cs.h1State.HeaderDeadlineNs.Load(); dl > 0 && now > dl {
-				_ = unix.SetsockoptLinger(fd, unix.SOL_SOCKET, unix.SO_LINGER, &unix.Linger{Onoff: 1, Linger: 0})
-				cs.forceRSTClose = true
+				_, _ = unix.Write(fd, requestTimeoutResponse)
 				l.closeConn(fd)
 				continue
 			}

--- a/engine/epoll/loop.go
+++ b/engine/epoll/loop.go
@@ -1588,18 +1588,6 @@ func (l *Loop) adaptiveTimeoutMs(base int) int {
 
 // checkTimeouts scans active connections and closes any that have exceeded
 // their configured timeout. Called every 1024 iterations (~100ms).
-// requestTimeoutResponse is the canonical HTTP/1.1 408 Request Timeout
-// response sent to slowloris clients before their conn is closed. Static
-// across calls; one allocation at package init. Content-Length: 0 keeps
-// the response to a single TCP segment (~80 bytes, well under MSS) so a
-// single unix.Write delivers it in one shot to the kernel send buffer.
-var requestTimeoutResponse = []byte(
-	"HTTP/1.1 408 Request Timeout\r\n" +
-		"Connection: close\r\n" +
-		"Content-Length: 0\r\n" +
-		"\r\n",
-)
-
 func (l *Loop) checkTimeouts() {
 	now := time.Now().UnixNano()
 	for fd := 0; fd <= l.maxFD; fd++ {
@@ -1618,30 +1606,17 @@ func (l *Loop) checkTimeouts() {
 			}
 			continue
 		}
-		// ReadHeaderTimeout: slowloris defence.
-		//
-		// Pre-fix: SHUT_RDWR + close + SO_LINGER{1,0} for RST. Empirically
-		// this left ~5-7% walker-side hangs on slow-refapp cells
-		// (observability + static_swagger_proxy) — FIN/RST visibility
-		// under cluster load is just unreliable enough that the walker's
-		// 20s drip-budget fires before its kernel observes the close on a
-		// small consistent fraction of attempts. Same shape on iouring +
-		// epoll despite their close paths being independent.
-		//
-		// Fix: write a 408 Request Timeout response synchronously via
-		// unix.Write (bytes hit the kernel send buffer immediately), then
-		// graceful-close via the default closeConn path. TCP retransmits
-		// response bytes if dropped → walker's Read returns 1 byte of
-		// response data → wellReject. No dependency on FIN/RST signaling.
-		//
-		// Sync write is fine on the event-loop thread: the response is
-		// ~80 bytes, well under MSS; the conn's send buffer is empty
-		// (server never wrote anything for slowloris) so EAGAIN is
-		// practically impossible. Even on partial write the walker
-		// observes the first byte and exits its drip loop.
+		// ReadHeaderTimeout: slowloris defence. Mirror net/http behavior:
+		// plain unix.Close (handled inside closeConn → fastClose branch),
+		// no shutdown, no linger, no response body. net/http on header
+		// timeout calls c.close() → plain Close; std walker shows 0
+		// hangs in probatorium. SHUT_RDWR+LINGER and 408+SHUT_WR+drain
+		// approaches both retained ~5-7% walker-hangs (nightly
+		// 26429150655 and predecessors), pointing at our extra syscalls
+		// racing with the walker's drip Write rather than at FIN/RST
+		// signaling. Simplest mirrors std.
 		if cs.h1State != nil {
 			if dl := cs.h1State.HeaderDeadlineNs.Load(); dl > 0 && now > dl {
-				_, _ = unix.Write(fd, requestTimeoutResponse)
 				l.closeConn(fd)
 				continue
 			}
@@ -1731,20 +1706,22 @@ func (l *Loop) closeConn(fd int) {
 		l.removeH2Conn(fd)
 	}
 	_ = unix.EpollCtl(l.epollFD, unix.EPOLL_CTL_DEL, fd, nil)
-	// Fast-close path for plain H1 connections: close() alone. Saves
-	// shutdown(SHUT_WR) + drainRecvBuffer syscalls (~2 per close) in
-	// the Connection:close churn hot path. Graceful path retained for
-	// H2 (GOAWAY / RST_STREAM flushing) and WS/SSE detach (middleware-
-	// queued close frames).
+	// Plain unix.Close for H1 connections (both sync and async-mode pre-
+	// allocated detachMu but not truly detached). Mirrors std/net.http
+	// c.close() → c.rwc.Close(): no shutdown, no linger, no drain. The
+	// shutdown+drain combo was leaving a ~5-7% walker-hang rate on
+	// probatorium slow-refapp slowloris cells (nightly 26429150655 et
+	// al), pointing at our extra syscalls racing with the peer's
+	// in-flight Write rather than at FIN/RST signaling per se.
 	//
-	// forceRSTClose (slowloris-defence): SHUT_RDWR + close — see
-	// iouring/worker.go finishCloseDetached for rationale.
-	fastClose := !detached && cs.protocol == engine.HTTP1 && cs.h1State != nil && !trulyDetached
+	// Graceful path retained for H2 (GOAWAY / RST_STREAM flushing) and
+	// for truly detached WS/SSE conns (middleware-queued close frames).
+	plainClose := cs.h1State != nil && !trulyDetached && cs.h2State == nil
 	switch {
 	case cs.forceRSTClose:
 		_ = unix.Shutdown(fd, unix.SHUT_RDWR)
 		_ = unix.Close(fd)
-	case fastClose:
+	case plainClose:
 		_ = unix.Close(fd)
 	default:
 		_ = unix.Shutdown(fd, unix.SHUT_WR)

--- a/engine/epoll/loop.go
+++ b/engine/epoll/loop.go
@@ -890,6 +890,12 @@ func (l *Loop) initProtocol(cs *connState) {
 		cs.h1State.EnableH2Upgrade = l.cfg.EnableH2Upgrade
 		cs.h1State.WorkerID = int32(l.id)
 		cs.h1State.WorkerIDSet = true
+		// Slowloris defence: configure + arm the read-header deadline.
+		// ProcessH1 clears on successful parse and rearms on return-nil
+		// (waiting for next request); checkTimeouts closes any conn
+		// that exceeds the deadline.
+		cs.h1State.ReadHeaderTimeoutNs = int64(l.cfg.ReadHeaderTimeout)
+		cs.h1State.ArmHeaderDeadline()
 		if !l.cfg.EnableH2Upgrade {
 			cs.h1State.DisableH2CDetect()
 		}
@@ -1546,6 +1552,17 @@ func (l *Loop) checkTimeouts() {
 				l.closeConn(fd)
 			}
 			continue
+		}
+		// ReadHeaderTimeout: slowloris defence. Mirrors the iouring
+		// worker's checkTimeouts; pre-v1.4.11 this gate was missing
+		// on the epoll engine so the std-only doc claim was a lie.
+		// HeaderDeadlineNs is armed at conn-accept and after each
+		// successful request parse (see ProcessH1 in internal/conn).
+		if cs.h1State != nil {
+			if dl := cs.h1State.HeaderDeadlineNs.Load(); dl > 0 && now > dl {
+				l.closeConn(fd)
+				continue
+			}
 		}
 		elapsed := time.Duration(now - cs.lastActivity)
 		if cs.dirty {

--- a/engine/epoll/loop.go
+++ b/engine/epoll/loop.go
@@ -1709,13 +1709,12 @@ func (l *Loop) closeConn(fd int) {
 	// H2 (GOAWAY / RST_STREAM flushing) and WS/SSE detach (middleware-
 	// queued close frames).
 	//
-	// forceRSTClose (slowloris-defence): plain close() with the
-	// SO_LINGER {1, 0} the caller set. No SHUT_* before — sending
-	// FIN first transitions the conn to FIN_WAIT_1 where LINGER may
-	// no longer fire RST on the subsequent close.
+	// forceRSTClose (slowloris-defence): SHUT_RDWR + close — see
+	// iouring/worker.go finishCloseDetached for rationale.
 	fastClose := !detached && cs.protocol == engine.HTTP1 && cs.h1State != nil && !trulyDetached
 	switch {
 	case cs.forceRSTClose:
+		_ = unix.Shutdown(fd, unix.SHUT_RDWR)
 		_ = unix.Close(fd)
 	case fastClose:
 		_ = unix.Close(fd)

--- a/engine/epoll/loop.go
+++ b/engine/epoll/loop.go
@@ -1553,13 +1553,15 @@ func (l *Loop) checkTimeouts() {
 			}
 			continue
 		}
-		// ReadHeaderTimeout: slowloris defence. Mirrors the iouring
-		// worker's checkTimeouts; pre-v1.4.11 this gate was missing
-		// on the epoll engine so the std-only doc claim was a lie.
-		// HeaderDeadlineNs is armed at conn-accept and after each
-		// successful request parse (see ProcessH1 in internal/conn).
+		// ReadHeaderTimeout: slowloris defence. Force RST close so the
+		// peer immediately observes termination on its next write —
+		// see iouring/worker.go handleHeaderTimer for the SO_LINGER {1,0}
+		// rationale. The fastClose path here is unchanged; we only flip
+		// the linger semantics for slowloris-triggered closes so the
+		// walker doesn't get fooled by TCP send-buffer hangover.
 		if cs.h1State != nil {
 			if dl := cs.h1State.HeaderDeadlineNs.Load(); dl > 0 && now > dl {
+				_ = unix.SetsockoptLinger(fd, unix.SOL_SOCKET, unix.SO_LINGER, &unix.Linger{Onoff: 1, Linger: 0})
 				l.closeConn(fd)
 				continue
 			}

--- a/engine/epoll/loop.go
+++ b/engine/epoll/loop.go
@@ -51,6 +51,7 @@ type Loop struct {
 	epollFD      int
 	listenFD     int
 	eventFD      int // eventfd for H2 write queue wakeup (-1 if unavailable)
+	timerFD      int // timerfd for kernel-enforced checkTimeouts cadence (-1 if disabled)
 	events       []unix.EpollEvent
 	conns        []*connState
 	connCount    int // number of active connections (local, for draining check)
@@ -131,6 +132,7 @@ func newLoop(id, cpuID int, handler stream.Handler,
 		epollFD:      -1,
 		listenFD:     -1,
 		eventFD:      -1,
+		timerFD:      -1,
 		events:       make([]unix.EpollEvent, resolved.MaxEvents),
 		conns:        make([]*connState, connTableSize),
 		handler:      handler,
@@ -210,6 +212,35 @@ func (l *Loop) run(ctx context.Context) {
 		}
 	}
 	l.eventFD = efd
+
+	// timerfd: forces checkTimeouts to run on a kernel-enforced 25ms
+	// cadence regardless of socket-event traffic. Without this, idle
+	// or low-traffic workers ran checkTimeouts only every ~800ms in
+	// the worst case (gate × adaptive_wait), eating into the
+	// slowloris walker's 2s slack budget for slow refapps. Mirrors
+	// the kernel-precision that iouring gets from per-conn
+	// IORING_OP_TIMEOUT SQEs.
+	if l.cfg.ReadHeaderTimeout > 0 {
+		tfd, tfdErr := unix.TimerfdCreate(unix.CLOCK_MONOTONIC, unix.TFD_NONBLOCK|unix.TFD_CLOEXEC)
+		if tfdErr == nil {
+			// 25ms periodic; first fire at 25ms too.
+			spec := unix.ItimerSpec{
+				Interval: unix.Timespec{Sec: 0, Nsec: 25 * 1000 * 1000},
+				Value:    unix.Timespec{Sec: 0, Nsec: 25 * 1000 * 1000},
+			}
+			if err := unix.TimerfdSettime(tfd, 0, &spec, nil); err != nil {
+				_ = unix.Close(tfd)
+				tfd = -1
+			} else if err := unix.EpollCtl(epollFD, unix.EPOLL_CTL_ADD, tfd, &unix.EpollEvent{
+				Events: unix.EPOLLIN,
+				Fd:     int32(tfd),
+			}); err != nil {
+				_ = unix.Close(tfd)
+				tfd = -1
+			}
+			l.timerFD = tfd
+		}
+	}
 
 	l.ready <- nil
 
@@ -313,6 +344,18 @@ func (l *Loop) run(ctx context.Context) {
 			if fd == l.eventFD && l.eventFD >= 0 {
 				var buf [8]byte
 				_, _ = unix.Read(l.eventFD, buf[:])
+				continue
+			}
+
+			// timerfd wakeup: drain the 8-byte expiration counter and
+			// fire checkTimeouts NOW so the slowloris HeaderDeadline
+			// hits within the kernel-precise 25ms cadence rather than
+			// the sweep gate's worst-case window. Mirrors iouring's
+			// per-conn IORING_OP_TIMEOUT precision on the epoll engine.
+			if fd == l.timerFD && l.timerFD >= 0 {
+				var buf [8]byte
+				_, _ = unix.Read(l.timerFD, buf[:])
+				l.checkTimeouts()
 				continue
 			}
 
@@ -1749,6 +1792,9 @@ func (l *Loop) shutdown() {
 	}
 	if l.eventFD >= 0 {
 		_ = unix.Close(l.eventFD)
+	}
+	if l.timerFD >= 0 {
+		_ = unix.Close(l.timerFD)
 	}
 	_ = unix.Close(l.epollFD)
 	// Wait for async dispatch goroutines to exit. They've been

--- a/engine/iouring/conn.go
+++ b/engine/iouring/conn.go
@@ -141,6 +141,16 @@ type connState struct {
 	// worker may call GetSQE). Cleared by drainDetachQueue after the
 	// bookkeeping runs, and by releaseConnState on teardown.
 	asyncDetachPending bool
+
+	// headerTimerSpec is the kernelTimespec passed to IORING_OP_TIMEOUT
+	// SQEs that enforce ReadHeaderTimeout per-conn. Owned by the conn
+	// (rather than per-SQE allocated) so the spec memory stays valid
+	// while the SQE is in the kernel queue. Re-used each arm.
+	headerTimerSpec kernelTimespec
+	// headerTimerArmed is true when a header-timer SQE has been submitted
+	// and the corresponding CQE has not yet been processed. Used to
+	// avoid duplicate timer SQEs.
+	headerTimerArmed bool
 }
 
 var connStatePool = sync.Pool{
@@ -199,6 +209,8 @@ func releaseConnState(cs *connState) {
 	cs.detachClosed = false
 	cs.recvPaused = false
 	cs.recvPauseDesired.Store(false)
+	cs.headerTimerSpec = kernelTimespec{}
+	cs.headerTimerArmed = false
 	cs.asyncInBuf = cs.asyncInBuf[:0]
 	cs.asyncOutBuf = cs.asyncOutBuf[:0]
 	cs.asyncRun = false

--- a/engine/iouring/conn.go
+++ b/engine/iouring/conn.go
@@ -151,6 +151,15 @@ type connState struct {
 	// and the corresponding CQE has not yet been processed. Used to
 	// avoid duplicate timer SQEs.
 	headerTimerArmed bool
+	// forceRSTClose is set by the slowloris-defence close paths
+	// (handleHeaderTimer + checkTimeouts HeaderDeadline branch) to
+	// signal that the conn should be torn down via RST instead of the
+	// usual graceful FIN+drain. finishClose / finishCloseDetached
+	// honor the flag by skipping Shutdown+drainRecvBuffer entirely and
+	// calling close() directly — SO_LINGER {1, 0} (set by the caller
+	// before closeConn) then forces RST. The walker's next write hits
+	// ECONNRESET immediately regardless of TCP send-buffer state.
+	forceRSTClose bool
 }
 
 var connStatePool = sync.Pool{
@@ -211,6 +220,7 @@ func releaseConnState(cs *connState) {
 	cs.recvPauseDesired.Store(false)
 	cs.headerTimerSpec = kernelTimespec{}
 	cs.headerTimerArmed = false
+	cs.forceRSTClose = false
 	cs.asyncInBuf = cs.asyncInBuf[:0]
 	cs.asyncOutBuf = cs.asyncOutBuf[:0]
 	cs.asyncRun = false

--- a/engine/iouring/consts.go
+++ b/engine/iouring/consts.go
@@ -30,7 +30,9 @@ const (
 	opNOP            = 0
 	opREADV          = 1
 	opWRITEV         = 2
-	opPOLLADD        = 6 // IORING_OP_POLL_ADD
+	opPOLLADD        = 6  // IORING_OP_POLL_ADD
+	opTIMEOUT        = 11 // IORING_OP_TIMEOUT (kernel 5.4+)
+	opTIMEOUTREMOVE  = 12 // IORING_OP_TIMEOUT_REMOVE (kernel 5.5+)
 	opACCEPT         = 13
 	opASYNCCANCEL    = 14
 	opCLOSE          = 19

--- a/engine/iouring/cqe.go
+++ b/engine/iouring/cqe.go
@@ -17,6 +17,12 @@ const (
 	udClose    uint64 = 0x04 << 56
 	udProvide  uint64 = 0x06 << 56
 	udH2Wakeup uint64 = 0x07 << 56
+	// udHeaderTimer tags IORING_OP_TIMEOUT SQEs submitted by initProtocol /
+	// ProcessH1's arm-callback to enforce ReadHeaderTimeout per-conn. The
+	// timer fires absolutely at the deadline; CQE handler closes the conn
+	// iff HeaderDeadlineNs is still > 0 and now > deadline (race-free
+	// against ClearHeaderDeadline). New in v1.4.11.
+	udHeaderTimer uint64 = 0x08 << 56
 	// Driver tags for EventLoopProvider — kept non-overlapping with HTTP tags
 	// so the main CQE dispatch can route them to the driver path without
 	// consulting the driverConns map.

--- a/engine/iouring/sqe.go
+++ b/engine/iouring/sqe.go
@@ -112,14 +112,22 @@ func setSQEUserData(sqePtr unsafe.Pointer, data uint64) {
 // count = 0: timer fires only on deadline (relative).
 // flags = 0: relative timer; pass IORING_TIMEOUT_ABS (1) for absolute.
 //
+// All non-timeout fields of the SQE are explicitly zeroed because the
+// SQ ring is reused — stale bytes from a previous SQE (fd, ioprio,
+// rw_flags) would otherwise confuse the kernel's IORING_OP_TIMEOUT
+// handler. Mirrors the prepAccept/prepRecv pattern in this file.
+//
 // New in v1.4.11 for the per-conn ReadHeaderTimeout enforcement.
 func prepTimeout(sqePtr unsafe.Pointer, ts unsafe.Pointer, count uint32, flags uint32) {
 	sqe := (*[sqeSize]byte)(sqePtr)
 	sqe[0] = opTIMEOUT
+	sqe[1] = 0                                          // flags
+	*(*uint16)(unsafe.Pointer(&sqe[2])) = 0             // ioprio
+	*(*int32)(unsafe.Pointer(&sqe[4])) = 0              // fd (unused)
+	*(*uint64)(unsafe.Pointer(&sqe[8])) = uint64(count) // off = count
 	*(*uint64)(unsafe.Pointer(&sqe[16])) = uint64(uintptr(ts))
-	*(*uint32)(unsafe.Pointer(&sqe[24])) = 1 // sqe.len: must be 1 for timeout
-	*(*uint64)(unsafe.Pointer(&sqe[8])) = uint64(count)
-	*(*uint32)(unsafe.Pointer(&sqe[28])) = flags // sqe.timeout_flags at off28
+	*(*uint32)(unsafe.Pointer(&sqe[24])) = 1     // len: must be 1
+	*(*uint32)(unsafe.Pointer(&sqe[28])) = flags // timeout_flags
 }
 
 // setSQEFixedFile sets the IOSQE_FIXED_FILE flag on an SQE after initial prep.

--- a/engine/iouring/sqe.go
+++ b/engine/iouring/sqe.go
@@ -101,6 +101,27 @@ func setSQEUserData(sqePtr unsafe.Pointer, data uint64) {
 	*(*uint64)(unsafe.Pointer(uintptr(sqePtr) + 32)) = data
 }
 
+// prepTimeout prepares an IORING_OP_TIMEOUT SQE that fires after the
+// duration described by ts. The kernel reads ts at submission time and
+// schedules an internal timer; when the timer fires (or the requested
+// number of completions arrive) the kernel returns a CQE with res=
+// -ETIME for the time path. ts MUST remain valid through submission —
+// kept on the conn state (see connState.headerTimerSpec) to satisfy
+// this requirement without per-arm heap allocation.
+//
+// count = 0: timer fires only on deadline (relative).
+// flags = 0: relative timer; pass IORING_TIMEOUT_ABS (1) for absolute.
+//
+// New in v1.4.11 for the per-conn ReadHeaderTimeout enforcement.
+func prepTimeout(sqePtr unsafe.Pointer, ts unsafe.Pointer, count uint32, flags uint32) {
+	sqe := (*[sqeSize]byte)(sqePtr)
+	sqe[0] = opTIMEOUT
+	*(*uint64)(unsafe.Pointer(&sqe[16])) = uint64(uintptr(ts))
+	*(*uint32)(unsafe.Pointer(&sqe[24])) = 1 // sqe.len: must be 1 for timeout
+	*(*uint64)(unsafe.Pointer(&sqe[8])) = uint64(count)
+	*(*uint32)(unsafe.Pointer(&sqe[28])) = flags // sqe.timeout_flags at off28
+}
+
 // setSQEFixedFile sets the IOSQE_FIXED_FILE flag on an SQE after initial prep.
 func setSQEFixedFile(sqePtr unsafe.Pointer) {
 	sqe := (*[sqeSize]byte)(sqePtr)

--- a/engine/iouring/worker.go
+++ b/engine/iouring/worker.go
@@ -752,10 +752,20 @@ func (w *Worker) armHeaderTimer(cs *connState) {
 	cs.headerTimerSpec.Nsec = remaining % int64(time.Second)
 	sqe := w.ring.GetSQE()
 	if sqe == nil {
-		// Ring full — fall back to sweep-based checkTimeouts. Not
-		// bulletproof but acceptable: the next CQE batch will drain
-		// the ring and the next initProtocol/arm will have a slot.
-		return
+		// Ring full — submit pending SQEs to drain, then retry.
+		// Without this, high-CQE-traffic cells (observability,
+		// static_swagger_proxy with concurrent Markov + adversarial
+		// walkers) silently dropped a fraction of timer arms; those
+		// conns then relied on the sweep, hitting the cadence floor.
+		// Surfaced by nightly 26397557463 where slow refapps still
+		// showed 62% slowloris hang rate post-forceRSTClose fix.
+		if _, err := w.ring.Submit(); err != nil {
+			return
+		}
+		sqe = w.ring.GetSQE()
+		if sqe == nil {
+			return
+		}
 	}
 	prepTimeout(sqe, unsafe.Pointer(&cs.headerTimerSpec), 0, 0)
 	setSQEUserData(sqe, encodeUserData(udHeaderTimer, cs.fd))

--- a/engine/iouring/worker.go
+++ b/engine/iouring/worker.go
@@ -978,16 +978,34 @@ func (w *Worker) initProtocol(cs *connState) {
 		cs.h1State.WorkerID = int32(w.id)
 		cs.h1State.WorkerIDSet = true
 		// Slowloris defence: kernel-enforced per-conn header deadline.
-		// The OnHeaderDeadlineArmed callback submits IORING_OP_TIMEOUT
-		// SQEs on every arm-transition (initial accept + each keep-alive
-		// next-request transition). The kernel fires the timer at the
-		// absolute deadline regardless of CQE traffic on the worker,
-		// giving parity with std's SetReadDeadline-based defence.
-		// checkTimeouts is the belt-and-braces fallback (now also gated
-		// tightly when ReadHeaderTimeout > 0).
+		//
+		// Sync mode (!w.async): ProcessH1 runs inline on the worker thread,
+		// so OnHeaderDeadlineArmed → armHeaderTimer is always a worker-
+		// thread call. Safe.
+		//
+		// Async mode (w.async): ProcessH1 runs on the per-conn dispatch
+		// goroutine. The keep-alive re-arm path (ProcessH1 sees
+		// HeaderDeadlineNs == 0 and calls ArmHeaderDeadline at line 360
+		// of internal/conn/h1.go) would fire OnHeaderDeadlineArmed from
+		// the goroutine, which would call w.ring.GetSQE — a violation of
+		// IORING_SETUP_SINGLE_ISSUER that can silently drop SQEs or
+		// corrupt the SQ ring. Leave OnHeaderDeadlineArmed nil in async
+		// mode; the initial accept-time arm fires via the direct
+		// armHeaderTimer call below (worker thread, safe), the recv-
+		// path retry (handleRecv) covers SQ-pressure drops, and keep-
+		// alive re-arms fall back to checkTimeouts which now runs every
+		// 32 iters × 25ms = 800ms worst case.
 		cs.h1State.ReadHeaderTimeoutNs = int64(w.cfg.ReadHeaderTimeout)
-		cs.h1State.OnHeaderDeadlineArmed = func() { w.armHeaderTimer(cs) }
+		if !w.async {
+			cs.h1State.OnHeaderDeadlineArmed = func() { w.armHeaderTimer(cs) }
+		}
 		cs.h1State.ArmHeaderDeadline()
+		if w.async {
+			// Direct worker-thread arm for the initial deadline; the
+			// nil OnHeaderDeadlineArmed above means ArmHeaderDeadline
+			// only stamped HeaderDeadlineNs, not the SQE.
+			w.armHeaderTimer(cs)
+		}
 		if !w.cfg.EnableH2Upgrade {
 			cs.h1State.DisableH2CDetect()
 		}

--- a/engine/iouring/worker.go
+++ b/engine/iouring/worker.go
@@ -1931,11 +1931,10 @@ func (w *Worker) finishClose(fd int) {
 	// close() without shutdown is equivalent on localhost and within
 	// noise on real networks.
 	//
-	// forceRSTClose (slowloris-defence): plain close() with the
-	// SO_LINGER {1, 0} the caller already set. NO shutdown before —
-	// shutdown(SHUT_*) sends FIN first which puts the conn in
-	// CLOSE_WAIT/FIN_WAIT_1 where LINGER may no longer trigger RST.
+	// forceRSTClose (slowloris-defence): SHUT_RDWR + close. See
+	// finishCloseDetached for the rationale.
 	if cs != nil && cs.forceRSTClose {
+		_ = unix.Shutdown(fd, unix.SHUT_RDWR)
 		_ = unix.Close(fd)
 		return
 	}
@@ -2003,20 +2002,14 @@ func (w *Worker) finishCloseDetached(fd int, cs *connState) {
 		return
 	}
 
-	// forceRSTClose: slowloris-defence path requested RST. The recipe
-	// to force RST on Linux regardless of receive-buffer state:
-	//
-	//   1. setsockopt TCP_REPAIR=1  (no-op fallback if not permitted)
-	//   2. setsockopt SO_LINGER {1, 0}  (caller already did this)
-	//   3. close(fd)  — kernel discards both TX and RX queues, RSTs
-	//
-	// Earlier attempt with shutdown(SHUT_RDWR) before close was
-	// trying to FORCE abortive close, but SHUT_RDWR sends FIN
-	// FIRST — the conn enters CLOSE_WAIT/FIN_WAIT_1 and SO_LINGER
-	// may no longer trigger RST on subsequent close. Removing the
-	// shutdown lets SO_LINGER take its intended effect on a
-	// still-ESTABLISHED conn.
+	// forceRSTClose: slowloris-defence path requested RST. Empirical
+	// data (nightly 26418830572 vs 26414322152): SHUT_RDWR + close
+	// gives ~50% more reliable observable-RST than plain close +
+	// LINGER on iouring. The SHUT_RDWR + LINGER combo wins because
+	// SHUT_RDWR drops the receive queue too (close() with LINGER
+	// only drops TX). Walker observes the abortive close immediately.
 	if cs.forceRSTClose {
+		_ = unix.Shutdown(fd, unix.SHUT_RDWR)
 		_ = unix.Close(fd)
 		return
 	}

--- a/engine/iouring/worker.go
+++ b/engine/iouring/worker.go
@@ -1931,10 +1931,16 @@ func (w *Worker) finishClose(fd int) {
 	// close() without shutdown is equivalent on localhost and within
 	// noise on real networks.
 	//
-	// forceRSTClose (slowloris-defence) also lands here: SO_LINGER {1,0}
-	// was set by the caller, so this plain close() will RST. The
-	// fastClose branch is fine for this case — H1, no in-flight body.
-	if fastClose || (cs != nil && cs.forceRSTClose) {
+	// forceRSTClose (slowloris-defence): SHUT_RDWR + SO_LINGER {1,0}
+	// + close = guaranteed RST regardless of receive-buffer state.
+	// See finishCloseDetached for the rationale.
+	if cs != nil && cs.forceRSTClose {
+		_ = unix.Shutdown(fd, unix.SHUT_RDWR)
+		_ = unix.Close(fd)
+		return
+	}
+	// fastClose: plain H1 no-body conn → close() alone suffices.
+	if fastClose {
 		_ = unix.Close(fd)
 		return
 	}
@@ -1998,14 +2004,20 @@ func (w *Worker) finishCloseDetached(fd int, cs *connState) {
 	}
 
 	// forceRSTClose: slowloris-defence path requested RST instead of
-	// FIN. Skip Shutdown(SHUT_WR) and drainRecvBuffer entirely —
-	// SO_LINGER {1, 0} was already set by the caller (see
-	// handleHeaderTimer / checkTimeouts HeaderDeadline branch), so
-	// close() will RST. SHUT_WR before close would put the conn into
-	// FIN_WAIT_1 first and may neutralise the linger semantics on some
-	// kernels; this path ensures the peer observes RST on its very
-	// next write regardless of state.
+	// FIN. SO_LINGER {1, 0} alone isn't reliable when the receive
+	// buffer is fully drained (our recv SQE consumed every slowloris
+	// drip byte as it arrived) — the kernel may still send FIN since
+	// there's no unread data to "discard". shutdown(SHUT_RDWR) FORCES
+	// abortive close: combined with LINGER 0 it always RSTs.
+	//
+	// std's http.Server gets this for free because its read goroutine
+	// frequently has unread bytes in the recv buffer when ReadHeader-
+	// Timeout fires (the deadline can interrupt a partial recv), so
+	// close() RSTs naturally. Our event-loop drains as bytes arrive,
+	// leaving the buffer empty at close time — hence the need for
+	// explicit SHUT_RDWR.
 	if cs.forceRSTClose {
+		_ = unix.Shutdown(fd, unix.SHUT_RDWR)
 		_ = unix.Close(fd)
 		return
 	}

--- a/engine/iouring/worker.go
+++ b/engine/iouring/worker.go
@@ -600,13 +600,22 @@ func (w *Worker) run(ctx context.Context) {
 		}
 
 		// Check connection timeouts. Default cadence is every 1024
-		// iterations (~100ms under load); when detached conns exist with
-		// idle deadlines the gate tightens to every 32 iterations
-		// (~50ms idle wall time) so the WS idle-close fires within its
-		// configured budget.
+		// iterations (~100ms under load); the gate tightens to every 32
+		// iterations (~50ms idle wall time) in two cases:
+		//   - detached conns exist with idle deadlines → WS idle-close
+		//     must fire within its configured budget.
+		//   - ReadHeaderTimeout > 0 → slowloris defence. The per-conn
+		//     IORING_OP_TIMEOUT is the primary mechanism but it can
+		//     silently drop arms under SQ-ring pressure (armHeaderTimer
+		//     returns without arming if GetSQE+Submit retry still fails).
+		//     The sweep is the belt-and-braces fallback; under heavy
+		//     legit traffic (observability+static_swagger_proxy) the
+		//     0x3FF gate is too coarse and the walker times out before
+		//     the sweep notices. Tightening to 0x1F caps the worst-case
+		//     close latency on a dropped arm to ~50ms.
 		w.tickCounter++
 		gate := uint32(0x3FF)
-		if w.detachedCount > 0 {
+		if w.detachedCount > 0 || w.cfg.ReadHeaderTimeout > 0 {
 			gate = 0x1F
 		}
 		if w.tickCounter&gate == 0 {
@@ -777,8 +786,10 @@ func (w *Worker) armHeaderTimer(cs *connState) {
 // periods, backs off to reduce syscall overhead (up to 100ms). When the
 // listen socket is closed (draining), uses 1s. When H2 connections exist
 // without eventfd, uses 100us for write queue polling. When detached
-// conns exist with idle deadlines, the cap drops to 50ms so checkTimeouts
-// can fire the WS-supplied IdleDeadline before its expiry.
+// conns exist with idle deadlines or ReadHeaderTimeout is configured, the
+// cap drops to 25ms so checkTimeouts can fire detached-idle deadlines
+// before expiry AND back up the per-conn IORING_OP_TIMEOUT for slowloris
+// defence when the kernel timer SQE failed to arm under SQ-ring pressure.
 func (w *Worker) adaptiveTimeout() time.Duration {
 	if w.listenFD < 0 {
 		return 1 * time.Second
@@ -792,6 +803,9 @@ func (w *Worker) adaptiveTimeout() time.Duration {
 	maxWait := 100 * time.Millisecond
 	if w.detachedCount > 0 {
 		maxWait = 50 * time.Millisecond
+	}
+	if w.cfg.ReadHeaderTimeout > 0 && maxWait > 25*time.Millisecond {
+		maxWait = 25 * time.Millisecond
 	}
 	switch {
 	case w.emptyIters <= 10:

--- a/engine/iouring/worker.go
+++ b/engine/iouring/worker.go
@@ -494,6 +494,12 @@ func (w *Worker) run(ctx context.Context) {
 				case udH2Wakeup:
 					w.handleH2Wakeup()
 				case udProvide:
+				case udHeaderTimer:
+					// MUST be in the inlined hot path — processCQE
+					// (which has the same case) is only called from
+					// the cancel path. Without this case, slowloris-
+					// defence timer CQEs are silently dropped.
+					w.handleHeaderTimer(fd, now)
 				case udDriverRecv:
 					w.handleDriverRecv(entry, fd)
 				case udDriverSend:
@@ -692,11 +698,16 @@ func (w *Worker) handleHeaderTimer(fd int, now int64) {
 		// fresh timer SQE.
 		return
 	}
+	// Re-read now from the kernel — cachedNow is refreshed only every
+	// 64 iterations, which could be 60+ms stale under bursty load.
+	// A stale now < dl comparison would spuriously re-arm a fresh
+	// 10s timer and effectively double the slowloris window. The
+	// fresh time.Now() costs one vDSO call, called only when a timer
+	// CQE arrives (rare in the hot path).
+	now = time.Now().UnixNano()
 	if now < dl {
-		// Spurious early fire (clock drift) or deadline got extended
-		// somehow — re-submit a fresh timer for the current deadline.
-		// Should be unreachable with idempotent ArmHeaderDeadline, but
-		// defensive.
+		// True early fire (kernel clock drift, very rare). Re-arm
+		// a fresh timer for the actual remaining time.
 		w.armHeaderTimer(cs)
 		return
 	}

--- a/engine/iouring/worker.go
+++ b/engine/iouring/worker.go
@@ -2072,13 +2072,21 @@ func (w *Worker) finishCloseDetached(fd int, cs *connState) {
 	// Async-mode HTTP1 conns are NOT truly detached (no WS/SSE middleware
 	// owns them) — they just pre-allocate detachMu in acquireConnState so
 	// the dispatch goroutine and worker can serialize writeBuf access.
-	// For these, plain unix.Close matches what std/net.http does on the
-	// equivalent path (c.close() → c.rwc.Close()) and avoids the
-	// SHUT_WR+drain race against a peer that may still be writing —
-	// the empirical signal from probatorium slow-refapp cells (nightly
-	// 26429150655 et al). SHUT_WR+drain+Close left a ~5-7% walker-hang
-	// rate; std's plain Close on the same probatorium walker shows 0.
+	//
+	// Plain unix.Close (matching net/http) sends FIN if the kernel recv
+	// buffer is empty, RST if non-empty. For slowloris, walker is still
+	// writing drips so the buffer often has unread bytes — close → RST.
+	// RST is NOT retransmitted by TCP, so if it's lost on the cluster
+	// fabric the walker never observes the close (walker hangs).
+	//
+	// SHUT_WR forces FIN explicitly (writer half-close) BEFORE close,
+	// regardless of recv-buffer state. FIN IS retransmitted from
+	// FIN_WAIT_1 until ACK'd, so packet loss can't strand the walker.
+	// No drainRecvBuffer (which was the prior approach's race source —
+	// the drain syscall and the close syscall left a multi-µs window in
+	// which a fresh walker drip would queue, making the close → RST).
 	if cs.h1State != nil && !cs.h1State.Detached {
+		_ = unix.Shutdown(fd, unix.SHUT_WR)
 		_ = unix.Close(fd)
 		return
 	}

--- a/engine/iouring/worker.go
+++ b/engine/iouring/worker.go
@@ -648,6 +648,8 @@ func (w *Worker) processCQE(ctx context.Context, c *completionEntry, now int64) 
 	case udH2Wakeup:
 		w.handleH2Wakeup()
 	case udProvide:
+	case udHeaderTimer:
+		w.handleHeaderTimer(fd, now)
 	case udDriverRecv:
 		w.handleDriverRecv(c, fd)
 	case udDriverSend:
@@ -655,6 +657,91 @@ func (w *Worker) processCQE(ctx context.Context, c *completionEntry, now int64) 
 	case udDriverClose:
 		w.handleDriverClose(fd)
 	}
+}
+
+// handleHeaderTimer processes an IORING_OP_TIMEOUT CQE submitted by
+// armHeaderTimer. The kernel fires it at the absolute deadline regardless
+// of CQE traffic on the worker, giving slowloris defence parity with
+// std's SetReadDeadline-based enforcement. The CQE is always processed —
+// no res check — because:
+//   - res == -ETIME on timer expiry (normal)
+//   - res == -ECANCELED if cancelled (we don't cancel, only let it fire)
+//   - res != 0 on any other error (we still need to clear headerTimerArmed)
+//
+// Race-free against ProcessH1's ClearHeaderDeadline: HeaderDeadlineNs is
+// atomic; if cleared between SQE submission and CQE arrival, the close
+// gate below skips the close. If re-armed in the same window (next
+// keep-alive request), the ArmHeaderDeadline callback submits a fresh
+// timer SQE — so we don't need to re-arm here.
+func (w *Worker) handleHeaderTimer(fd int, now int64) {
+	if fd < 0 || fd > w.maxFD {
+		return
+	}
+	cs := w.conns[fd]
+	if cs == nil {
+		return
+	}
+	cs.headerTimerArmed = false
+	if cs.closing || cs.h1State == nil {
+		return
+	}
+	dl := cs.h1State.HeaderDeadlineNs.Load()
+	if dl == 0 {
+		// Headers completed before the timer fired; no-op. The next
+		// ArmHeaderDeadline (keep-alive next request) will submit a
+		// fresh timer SQE.
+		return
+	}
+	if now < dl {
+		// Spurious early fire (clock drift) or deadline got extended
+		// somehow — re-submit a fresh timer for the current deadline.
+		// Should be unreachable with idempotent ArmHeaderDeadline, but
+		// defensive.
+		w.armHeaderTimer(cs)
+		return
+	}
+	// Deadline exceeded — slowloris defence fires.
+	w.closeConn(fd)
+}
+
+// armHeaderTimer submits an IORING_OP_TIMEOUT SQE that fires at
+// cs.h1State.HeaderDeadlineNs. Called from initProtocol on conn-accept
+// and from the OnHeaderDeadlineArmed callback when ProcessH1 re-arms
+// for a keep-alive next request.
+//
+// Idempotent: if a timer is already in flight (cs.headerTimerArmed),
+// the new arm is a no-op — the in-flight timer's CQE will check the
+// current HeaderDeadlineNs and either close or re-submit as needed.
+// Without this guard a fast-cycling keep-alive client could queue many
+// in-flight timer SQEs for the same conn, exhausting the SQ ring.
+func (w *Worker) armHeaderTimer(cs *connState) {
+	if cs.h1State == nil || cs.headerTimerArmed {
+		return
+	}
+	dl := cs.h1State.HeaderDeadlineNs.Load()
+	if dl == 0 {
+		return
+	}
+	now := time.Now().UnixNano()
+	remaining := dl - now
+	if remaining <= 0 {
+		// Deadline already past — close immediately rather than queue
+		// a zero-duration timer (kernel would fire it instantly anyway).
+		w.closeConn(cs.fd)
+		return
+	}
+	cs.headerTimerSpec.Sec = remaining / int64(time.Second)
+	cs.headerTimerSpec.Nsec = remaining % int64(time.Second)
+	sqe := w.ring.GetSQE()
+	if sqe == nil {
+		// Ring full — fall back to sweep-based checkTimeouts. Not
+		// bulletproof but acceptable: the next CQE batch will drain
+		// the ring and the next initProtocol/arm will have a slot.
+		return
+	}
+	prepTimeout(sqe, unsafe.Pointer(&cs.headerTimerSpec), 0, 0)
+	setSQEUserData(sqe, encodeUserData(udHeaderTimer, cs.fd))
+	cs.headerTimerArmed = true
 }
 
 // adaptiveTimeout returns a wait timeout that scales with idle duration.
@@ -848,11 +935,16 @@ func (w *Worker) initProtocol(cs *connState) {
 		cs.h1State.EnableH2Upgrade = w.cfg.EnableH2Upgrade
 		cs.h1State.WorkerID = int32(w.id)
 		cs.h1State.WorkerIDSet = true
-		// Slowloris defence: arm the header read deadline so checkTimeouts
-		// closes any conn that fails to complete headers in time. ProcessH1
-		// clears it on successful parse; it rearms on return-nil
-		// (await-more-data) using ReadHeaderTimeoutNs stored here.
+		// Slowloris defence: kernel-enforced per-conn header deadline.
+		// The OnHeaderDeadlineArmed callback submits IORING_OP_TIMEOUT
+		// SQEs on every arm-transition (initial accept + each keep-alive
+		// next-request transition). The kernel fires the timer at the
+		// absolute deadline regardless of CQE traffic on the worker,
+		// giving parity with std's SetReadDeadline-based defence.
+		// checkTimeouts is the belt-and-braces fallback (now also gated
+		// tightly when ReadHeaderTimeout > 0).
 		cs.h1State.ReadHeaderTimeoutNs = int64(w.cfg.ReadHeaderTimeout)
+		cs.h1State.OnHeaderDeadlineArmed = func() { w.armHeaderTimer(cs) }
 		cs.h1State.ArmHeaderDeadline()
 		if !w.cfg.EnableH2Upgrade {
 			cs.h1State.DisableH2CDetect()

--- a/engine/iouring/worker.go
+++ b/engine/iouring/worker.go
@@ -719,44 +719,19 @@ func (w *Worker) handleHeaderTimer(fd int) {
 		w.armHeaderTimer(cs)
 		return
 	}
-	// Deadline exceeded — slowloris defence fires.
-	//
-	// Pre-fix: SHUT_RDWR + close + SO_LINGER{1,0} to force RST. Empirically
-	// this left ~5-7% of slowloris conns in walker-hang state across slow-
-	// refapp cells (observability + static_swagger_proxy on iouring +
-	// epoll) — FIN/RST visibility under cluster load is just unreliable
-	// enough that the walker's drip-budget timer (20s) fires before its
-	// kernel observes the close on a small but consistent fraction of
-	// attempts. Same shape on iouring AND epoll, ruling out engine-
-	// specific causes.
-	//
-	// Fix: write a 408 Request Timeout response BEFORE closing. The
-	// response bytes flow through TCP's reliable-delivery path
-	// (retransmits if dropped), and the walker's Read returns 1 byte of
-	// response data → wellReject. No dependency on FIN/RST signaling. The
-	// kernel sends FIN after the response drains (graceful close, no
-	// LINGER) — walker observes EOF on its next Read too, belt-and-braces.
-	//
-	// cs.writeFn appends to cs.writeBuf — safe from the worker thread.
-	// closeConn sees the non-empty writeBuf and defers the close until
-	// the SEND CQE completes; finishCloseDetached then takes the graceful
-	// SHUT_WR + drainRecvBuffer + Close path (no forceRSTClose), so the
-	// 408 reliably leaves the kernel before the FIN.
-	cs.writeFn(requestTimeoutResponse)
+	// Deadline exceeded — slowloris defence fires. Mirror std/net.http's
+	// approach: plain unix.Close, no shutdown, no linger, no response.
+	// net/http on hdrDeadline → isCommonNetReadError → "don't reply",
+	// then c.close() → c.rwc.Close() (plain TCP close). Std walker shows
+	// 0 hangs on the exact same probatorium test. We previously tried:
+	//   - SHUT_RDWR + close + LINGER{1,0} (RST) → ~17-21 hangs per cell
+	//   - 408 response + SHUT_WR + drain + close → ~17-25 hangs per cell
+	// Both elaborate paths had the same ~5-7% walker-hang rate.
+	// Suspect: SHUT_*/drain syscalls + LINGER each create their own
+	// timing race vs. the walker's drip Write; plain close is simpler
+	// and matches the observed-working std behavior exactly.
 	w.closeConn(fd)
 }
-
-// requestTimeoutResponse is the canonical HTTP/1.1 408 Request Timeout
-// response sent to slowloris clients before their conn is closed. Static
-// across calls (no per-conn state); single allocation at package init.
-// Content-Length: 0 matches the no-body convention and keeps the response
-// to a single TCP segment (~80 bytes well under MSS).
-var requestTimeoutResponse = []byte(
-	"HTTP/1.1 408 Request Timeout\r\n" +
-		"Connection: close\r\n" +
-		"Content-Length: 0\r\n" +
-		"\r\n",
-)
 
 // armHeaderTimer submits an IORING_OP_TIMEOUT SQE that fires at
 // cs.h1State.HeaderDeadlineNs. Called from initProtocol on conn-accept
@@ -2094,14 +2069,23 @@ func (w *Worker) finishCloseDetached(fd int, cs *connState) {
 		_ = unix.Close(fd)
 		return
 	}
-	// Detached connections still use the graceful half-close path —
-	// middleware (WebSocket / SSE) may have queued a close-frame echo
-	// that we want to let finish cleanly, and the middleware goroutine
-	// already drove the protocol handshake to completion before asking
-	// the engine to drop the FD. RST close (as used by closeNonFixedFD
-	// for plain H1/H2) would cut that echo off. The graceful path is
-	// still SYNC (unix.Close directly) to avoid the async-SQE pile-up
-	// that plagued the pre-patch version.
+	// Async-mode HTTP1 conns are NOT truly detached (no WS/SSE middleware
+	// owns them) — they just pre-allocate detachMu in acquireConnState so
+	// the dispatch goroutine and worker can serialize writeBuf access.
+	// For these, plain unix.Close matches what std/net.http does on the
+	// equivalent path (c.close() → c.rwc.Close()) and avoids the
+	// SHUT_WR+drain race against a peer that may still be writing —
+	// the empirical signal from probatorium slow-refapp cells (nightly
+	// 26429150655 et al). SHUT_WR+drain+Close left a ~5-7% walker-hang
+	// rate; std's plain Close on the same probatorium walker shows 0.
+	if cs.h1State != nil && !cs.h1State.Detached {
+		_ = unix.Close(fd)
+		return
+	}
+	// Truly detached (WS/SSE): graceful half-close so middleware-queued
+	// close-frame echoes flush before the FIN. Sync unix.Close (not via
+	// io_uring) to avoid the async-SQE pile-up that plagued the pre-patch
+	// version.
 	_ = unix.Shutdown(fd, unix.SHUT_WR)
 	drainRecvBuffer(fd)
 	_ = unix.Close(fd)
@@ -2785,19 +2769,11 @@ func (w *Worker) checkTimeouts() {
 			}
 			continue
 		}
-		// ReadHeaderTimeout: slowloris defence. Set by the engine on
-		// fresh conns and after each successful request parse — cleared
-		// when ProcessH1 finishes a request. A non-zero value past the
-		// deadline means the peer is dripping headers slowly. Write a
-		// 408 Request Timeout response then graceful-close — see
-		// handleHeaderTimer for the TCP-reliable-delivery rationale (the
-		// RST-only approach left ~5-7% walker-side hangs under cluster
-		// load due to FIN/RST packet-loss; response bytes are
-		// retransmitted, response data → walker Read returns 1 byte →
-		// wellReject without any dependency on FIN/RST visibility).
+		// ReadHeaderTimeout: slowloris defence. Plain unix.Close path
+		// (handled by closeConn → finishCloseDetached fastClose branch).
+		// See handleHeaderTimer for the rationale (mirrors net/http).
 		if cs.h1State != nil {
 			if dl := cs.h1State.HeaderDeadlineNs.Load(); dl > 0 && now > dl {
-				cs.writeFn(requestTimeoutResponse)
 				w.closeConn(fd)
 				continue
 			}

--- a/engine/iouring/worker.go
+++ b/engine/iouring/worker.go
@@ -1393,6 +1393,19 @@ func (w *Worker) handleRecv(c *completionEntry, fd int, now int64) {
 			cs.asyncCond.Signal()
 		}
 		w.reqBatch++
+		// Re-attempt the slowloris-defence timer arm if the initial
+		// attempt (from initProtocol on accept) silently dropped under
+		// SQ-ring pressure. ArmHeaderDeadline is idempotent on
+		// HeaderDeadlineNs, so it won't reset the deadline; but
+		// armHeaderTimer's headerTimerArmed gate means we only retry
+		// the SQE submission if the prior arm is not in flight. This
+		// is the explicit "retry on next recv" path that was missing —
+		// without it, a conn whose initial arm failed relies entirely
+		// on the sweep, doubling worst-case close latency on slow
+		// refapps (observability/static_swagger_proxy).
+		if cs.h1State != nil && cs.h1State.HeaderDeadlineNs.Load() > 0 && !cs.headerTimerArmed {
+			w.armHeaderTimer(cs)
+		}
 		if !cqeHasMore(c.Flags) && !cs.recvPaused {
 			if !w.prepareRecv(fd, cs.buf) {
 				cs.needsRecv = true
@@ -1494,6 +1507,15 @@ func (w *Worker) handleRecv(c *completionEntry, fd int, now int64) {
 	}
 
 	w.reqBatch++
+
+	// Slowloris-defence: retry timer arm if the initial attempt dropped
+	// silently under SQ-ring pressure. Mirrors the async-path retry above.
+	// Sync mode: ProcessH1 is idempotent on HeaderDeadlineNs so it won't
+	// re-trigger OnHeaderDeadlineArmed if the deadline is already set,
+	// leaving conns whose initial arm failed dependent on the sweep alone.
+	if cs.h1State != nil && cs.h1State.HeaderDeadlineNs.Load() > 0 && !cs.headerTimerArmed {
+		w.armHeaderTimer(cs)
+	}
 
 	// lastActivity already set above; timeout checked in checkTimeouts.
 

--- a/engine/iouring/worker.go
+++ b/engine/iouring/worker.go
@@ -848,6 +848,12 @@ func (w *Worker) initProtocol(cs *connState) {
 		cs.h1State.EnableH2Upgrade = w.cfg.EnableH2Upgrade
 		cs.h1State.WorkerID = int32(w.id)
 		cs.h1State.WorkerIDSet = true
+		// Slowloris defence: arm the header read deadline so checkTimeouts
+		// closes any conn that fails to complete headers in time. ProcessH1
+		// clears it on successful parse; it rearms on return-nil
+		// (await-more-data) using ReadHeaderTimeoutNs stored here.
+		cs.h1State.ReadHeaderTimeoutNs = int64(w.cfg.ReadHeaderTimeout)
+		cs.h1State.ArmHeaderDeadline()
 		if !w.cfg.EnableH2Upgrade {
 			cs.h1State.DisableH2CDetect()
 		}
@@ -2557,6 +2563,20 @@ func (w *Worker) checkTimeouts() {
 				w.closeConn(fd)
 			}
 			continue
+		}
+		// ReadHeaderTimeout: slowloris defence. Set by the engine on
+		// fresh conns and after each successful request parse — cleared
+		// when ProcessH1 finishes a request. A non-zero value past the
+		// deadline means the peer is dripping headers slowly: close.
+		// Pre-v1.4.11 this check was missing on iouring/epoll; only the
+		// std engine honored ReadHeaderTimeout. Probatorium soak
+		// 26363052652 surfaced 1,910 adv_hang events distributed across
+		// iouring + epoll cells that had this gap.
+		if cs.h1State != nil {
+			if dl := cs.h1State.HeaderDeadlineNs.Load(); dl > 0 && now > dl {
+				w.closeConn(fd)
+				continue
+			}
 		}
 		elapsed := time.Duration(now - cs.lastActivity)
 		if cs.dirty || cs.sending {

--- a/engine/iouring/worker.go
+++ b/engine/iouring/worker.go
@@ -710,24 +710,15 @@ func (w *Worker) handleHeaderTimer(fd int) {
 		w.armHeaderTimer(cs)
 		return
 	}
-	// Deadline exceeded — slowloris defence fires.
-	//
-	// Force RST instead of FIN: comparison with std (which had 0
-	// hangs) revealed std processed 4-15x MORE slowloris attempts
-	// per cell budget than iouring, meaning std's close caused the
-	// walker to immediately fail its next write. iouring's graceful
-	// SHUT_WR+drain+close path (used by async mode) sent FIN; the
-	// walker's small drip writes could continue buffering locally
-	// past the close, often reaching the 12s hang budget without
-	// noticing.
-	//
-	// SO_LINGER {1, 0} discards any pending TX data and sends RST
-	// on close — walker observes ECONNRESET on its very next write,
-	// independent of TCP send-buffer state. The conn is being
-	// terminated for being slow regardless, so we don't care about
-	// graceful tx drain. Mirrors how production proxies (nginx
-	// reset_timedout_connection on) handle the same case.
+	// Deadline exceeded — slowloris defence fires. Force RST close so
+	// the peer observes ECONNRESET on its next write, independent of
+	// TCP send-buffer state. SO_LINGER {1, 0} + forceRSTClose=true
+	// (which makes finishClose / finishCloseDetached skip the
+	// graceful SHUT_WR+drain path that would otherwise leave the conn
+	// in FIN_WAIT and let the walker's drip writes succeed locally
+	// past the close). Mirrors nginx reset_timedout_connection on.
 	_ = unix.SetsockoptLinger(fd, unix.SOL_SOCKET, unix.SO_LINGER, &unix.Linger{Onoff: 1, Linger: 0})
+	cs.forceRSTClose = true
 	w.closeConn(fd)
 }
 
@@ -1929,7 +1920,11 @@ func (w *Worker) finishClose(fd int) {
 	// frames so the peer sees them. For H1 without a body in-flight,
 	// close() without shutdown is equivalent on localhost and within
 	// noise on real networks.
-	if fastClose {
+	//
+	// forceRSTClose (slowloris-defence) also lands here: SO_LINGER {1,0}
+	// was set by the caller, so this plain close() will RST. The
+	// fastClose branch is fine for this case — H1, no in-flight body.
+	if fastClose || (cs != nil && cs.forceRSTClose) {
 		_ = unix.Close(fd)
 		return
 	}
@@ -1992,6 +1987,18 @@ func (w *Worker) finishCloseDetached(fd int, cs *connState) {
 		return
 	}
 
+	// forceRSTClose: slowloris-defence path requested RST instead of
+	// FIN. Skip Shutdown(SHUT_WR) and drainRecvBuffer entirely —
+	// SO_LINGER {1, 0} was already set by the caller (see
+	// handleHeaderTimer / checkTimeouts HeaderDeadline branch), so
+	// close() will RST. SHUT_WR before close would put the conn into
+	// FIN_WAIT_1 first and may neutralise the linger semantics on some
+	// kernels; this path ensures the peer observes RST on its very
+	// next write regardless of state.
+	if cs.forceRSTClose {
+		_ = unix.Close(fd)
+		return
+	}
 	// Detached connections still use the graceful half-close path —
 	// middleware (WebSocket / SSE) may have queued a close-frame echo
 	// that we want to let finish cleanly, and the middleware goroutine
@@ -2688,10 +2695,12 @@ func (w *Worker) checkTimeouts() {
 		// when ProcessH1 finishes a request. A non-zero value past the
 		// deadline means the peer is dripping headers slowly: force RST
 		// close so the peer observes the termination on its very next
-		// write. See handleHeaderTimer for the SO_LINGER {1,0} rationale.
+		// write. See handleHeaderTimer for the SO_LINGER {1,0} +
+		// forceRSTClose rationale.
 		if cs.h1State != nil {
 			if dl := cs.h1State.HeaderDeadlineNs.Load(); dl > 0 && now > dl {
 				_ = unix.SetsockoptLinger(fd, unix.SOL_SOCKET, unix.SO_LINGER, &unix.Linger{Onoff: 1, Linger: 0})
+				cs.forceRSTClose = true
 				w.closeConn(fd)
 				continue
 			}

--- a/engine/iouring/worker.go
+++ b/engine/iouring/worker.go
@@ -1931,11 +1931,11 @@ func (w *Worker) finishClose(fd int) {
 	// close() without shutdown is equivalent on localhost and within
 	// noise on real networks.
 	//
-	// forceRSTClose (slowloris-defence): SHUT_RDWR + SO_LINGER {1,0}
-	// + close = guaranteed RST regardless of receive-buffer state.
-	// See finishCloseDetached for the rationale.
+	// forceRSTClose (slowloris-defence): plain close() with the
+	// SO_LINGER {1, 0} the caller already set. NO shutdown before —
+	// shutdown(SHUT_*) sends FIN first which puts the conn in
+	// CLOSE_WAIT/FIN_WAIT_1 where LINGER may no longer trigger RST.
 	if cs != nil && cs.forceRSTClose {
-		_ = unix.Shutdown(fd, unix.SHUT_RDWR)
 		_ = unix.Close(fd)
 		return
 	}
@@ -2003,21 +2003,20 @@ func (w *Worker) finishCloseDetached(fd int, cs *connState) {
 		return
 	}
 
-	// forceRSTClose: slowloris-defence path requested RST instead of
-	// FIN. SO_LINGER {1, 0} alone isn't reliable when the receive
-	// buffer is fully drained (our recv SQE consumed every slowloris
-	// drip byte as it arrived) — the kernel may still send FIN since
-	// there's no unread data to "discard". shutdown(SHUT_RDWR) FORCES
-	// abortive close: combined with LINGER 0 it always RSTs.
+	// forceRSTClose: slowloris-defence path requested RST. The recipe
+	// to force RST on Linux regardless of receive-buffer state:
 	//
-	// std's http.Server gets this for free because its read goroutine
-	// frequently has unread bytes in the recv buffer when ReadHeader-
-	// Timeout fires (the deadline can interrupt a partial recv), so
-	// close() RSTs naturally. Our event-loop drains as bytes arrive,
-	// leaving the buffer empty at close time — hence the need for
-	// explicit SHUT_RDWR.
+	//   1. setsockopt TCP_REPAIR=1  (no-op fallback if not permitted)
+	//   2. setsockopt SO_LINGER {1, 0}  (caller already did this)
+	//   3. close(fd)  — kernel discards both TX and RX queues, RSTs
+	//
+	// Earlier attempt with shutdown(SHUT_RDWR) before close was
+	// trying to FORCE abortive close, but SHUT_RDWR sends FIN
+	// FIRST — the conn enters CLOSE_WAIT/FIN_WAIT_1 and SO_LINGER
+	// may no longer trigger RST on subsequent close. Removing the
+	// shutdown lets SO_LINGER take its intended effect on a
+	// still-ESTABLISHED conn.
 	if cs.forceRSTClose {
-		_ = unix.Shutdown(fd, unix.SHUT_RDWR)
 		_ = unix.Close(fd)
 		return
 	}

--- a/engine/iouring/worker.go
+++ b/engine/iouring/worker.go
@@ -719,17 +719,44 @@ func (w *Worker) handleHeaderTimer(fd int) {
 		w.armHeaderTimer(cs)
 		return
 	}
-	// Deadline exceeded — slowloris defence fires. Force RST close so
-	// the peer observes ECONNRESET on its next write, independent of
-	// TCP send-buffer state. SO_LINGER {1, 0} + forceRSTClose=true
-	// (which makes finishClose / finishCloseDetached skip the
-	// graceful SHUT_WR+drain path that would otherwise leave the conn
-	// in FIN_WAIT and let the walker's drip writes succeed locally
-	// past the close). Mirrors nginx reset_timedout_connection on.
-	_ = unix.SetsockoptLinger(fd, unix.SOL_SOCKET, unix.SO_LINGER, &unix.Linger{Onoff: 1, Linger: 0})
-	cs.forceRSTClose = true
+	// Deadline exceeded — slowloris defence fires.
+	//
+	// Pre-fix: SHUT_RDWR + close + SO_LINGER{1,0} to force RST. Empirically
+	// this left ~5-7% of slowloris conns in walker-hang state across slow-
+	// refapp cells (observability + static_swagger_proxy on iouring +
+	// epoll) — FIN/RST visibility under cluster load is just unreliable
+	// enough that the walker's drip-budget timer (20s) fires before its
+	// kernel observes the close on a small but consistent fraction of
+	// attempts. Same shape on iouring AND epoll, ruling out engine-
+	// specific causes.
+	//
+	// Fix: write a 408 Request Timeout response BEFORE closing. The
+	// response bytes flow through TCP's reliable-delivery path
+	// (retransmits if dropped), and the walker's Read returns 1 byte of
+	// response data → wellReject. No dependency on FIN/RST signaling. The
+	// kernel sends FIN after the response drains (graceful close, no
+	// LINGER) — walker observes EOF on its next Read too, belt-and-braces.
+	//
+	// cs.writeFn appends to cs.writeBuf — safe from the worker thread.
+	// closeConn sees the non-empty writeBuf and defers the close until
+	// the SEND CQE completes; finishCloseDetached then takes the graceful
+	// SHUT_WR + drainRecvBuffer + Close path (no forceRSTClose), so the
+	// 408 reliably leaves the kernel before the FIN.
+	cs.writeFn(requestTimeoutResponse)
 	w.closeConn(fd)
 }
+
+// requestTimeoutResponse is the canonical HTTP/1.1 408 Request Timeout
+// response sent to slowloris clients before their conn is closed. Static
+// across calls (no per-conn state); single allocation at package init.
+// Content-Length: 0 matches the no-body convention and keeps the response
+// to a single TCP segment (~80 bytes well under MSS).
+var requestTimeoutResponse = []byte(
+	"HTTP/1.1 408 Request Timeout\r\n" +
+		"Connection: close\r\n" +
+		"Content-Length: 0\r\n" +
+		"\r\n",
+)
 
 // armHeaderTimer submits an IORING_OP_TIMEOUT SQE that fires at
 // cs.h1State.HeaderDeadlineNs. Called from initProtocol on conn-accept
@@ -2761,14 +2788,16 @@ func (w *Worker) checkTimeouts() {
 		// ReadHeaderTimeout: slowloris defence. Set by the engine on
 		// fresh conns and after each successful request parse — cleared
 		// when ProcessH1 finishes a request. A non-zero value past the
-		// deadline means the peer is dripping headers slowly: force RST
-		// close so the peer observes the termination on its very next
-		// write. See handleHeaderTimer for the SO_LINGER {1,0} +
-		// forceRSTClose rationale.
+		// deadline means the peer is dripping headers slowly. Write a
+		// 408 Request Timeout response then graceful-close — see
+		// handleHeaderTimer for the TCP-reliable-delivery rationale (the
+		// RST-only approach left ~5-7% walker-side hangs under cluster
+		// load due to FIN/RST packet-loss; response bytes are
+		// retransmitted, response data → walker Read returns 1 byte →
+		// wellReject without any dependency on FIN/RST visibility).
 		if cs.h1State != nil {
 			if dl := cs.h1State.HeaderDeadlineNs.Load(); dl > 0 && now > dl {
-				_ = unix.SetsockoptLinger(fd, unix.SOL_SOCKET, unix.SO_LINGER, &unix.Linger{Onoff: 1, Linger: 0})
-				cs.forceRSTClose = true
+				cs.writeFn(requestTimeoutResponse)
 				w.closeConn(fd)
 				continue
 			}

--- a/engine/iouring/worker.go
+++ b/engine/iouring/worker.go
@@ -711,6 +711,23 @@ func (w *Worker) handleHeaderTimer(fd int) {
 		return
 	}
 	// Deadline exceeded — slowloris defence fires.
+	//
+	// Force RST instead of FIN: comparison with std (which had 0
+	// hangs) revealed std processed 4-15x MORE slowloris attempts
+	// per cell budget than iouring, meaning std's close caused the
+	// walker to immediately fail its next write. iouring's graceful
+	// SHUT_WR+drain+close path (used by async mode) sent FIN; the
+	// walker's small drip writes could continue buffering locally
+	// past the close, often reaching the 12s hang budget without
+	// noticing.
+	//
+	// SO_LINGER {1, 0} discards any pending TX data and sends RST
+	// on close — walker observes ECONNRESET on its very next write,
+	// independent of TCP send-buffer state. The conn is being
+	// terminated for being slow regardless, so we don't care about
+	// graceful tx drain. Mirrors how production proxies (nginx
+	// reset_timedout_connection on) handle the same case.
+	_ = unix.SetsockoptLinger(fd, unix.SOL_SOCKET, unix.SO_LINGER, &unix.Linger{Onoff: 1, Linger: 0})
 	w.closeConn(fd)
 }
 
@@ -2669,13 +2686,12 @@ func (w *Worker) checkTimeouts() {
 		// ReadHeaderTimeout: slowloris defence. Set by the engine on
 		// fresh conns and after each successful request parse — cleared
 		// when ProcessH1 finishes a request. A non-zero value past the
-		// deadline means the peer is dripping headers slowly: close.
-		// Pre-v1.4.11 this check was missing on iouring/epoll; only the
-		// std engine honored ReadHeaderTimeout. Probatorium soak
-		// 26363052652 surfaced 1,910 adv_hang events distributed across
-		// iouring + epoll cells that had this gap.
+		// deadline means the peer is dripping headers slowly: force RST
+		// close so the peer observes the termination on its very next
+		// write. See handleHeaderTimer for the SO_LINGER {1,0} rationale.
 		if cs.h1State != nil {
 			if dl := cs.h1State.HeaderDeadlineNs.Load(); dl > 0 && now > dl {
+				_ = unix.SetsockoptLinger(fd, unix.SOL_SOCKET, unix.SO_LINGER, &unix.Linger{Onoff: 1, Linger: 0})
 				w.closeConn(fd)
 				continue
 			}

--- a/engine/iouring/worker.go
+++ b/engine/iouring/worker.go
@@ -499,7 +499,7 @@ func (w *Worker) run(ctx context.Context) {
 					// (which has the same case) is only called from
 					// the cancel path. Without this case, slowloris-
 					// defence timer CQEs are silently dropped.
-					w.handleHeaderTimer(fd, now)
+					w.handleHeaderTimer(fd)
 				case udDriverRecv:
 					w.handleDriverRecv(entry, fd)
 				case udDriverSend:
@@ -655,7 +655,7 @@ func (w *Worker) processCQE(ctx context.Context, c *completionEntry, now int64) 
 		w.handleH2Wakeup()
 	case udProvide:
 	case udHeaderTimer:
-		w.handleHeaderTimer(fd, now)
+		w.handleHeaderTimer(fd)
 	case udDriverRecv:
 		w.handleDriverRecv(c, fd)
 	case udDriverSend:
@@ -679,7 +679,12 @@ func (w *Worker) processCQE(ctx context.Context, c *completionEntry, now int64) 
 // gate below skips the close. If re-armed in the same window (next
 // keep-alive request), the ArmHeaderDeadline callback submits a fresh
 // timer SQE — so we don't need to re-arm here.
-func (w *Worker) handleHeaderTimer(fd int, now int64) {
+// handleHeaderTimer ignores the caller's `now` because cachedNow is
+// refreshed only every 64 iterations (60+ms stale under bursty load)
+// and a stale now < dl comparison would spuriously re-arm a fresh 10s
+// timer, effectively doubling the slowloris window. One vDSO call per
+// timer CQE — rare in the hot path — is the right trade-off.
+func (w *Worker) handleHeaderTimer(fd int) {
 	if fd < 0 || fd > w.maxFD {
 		return
 	}
@@ -698,13 +703,7 @@ func (w *Worker) handleHeaderTimer(fd int, now int64) {
 		// fresh timer SQE.
 		return
 	}
-	// Re-read now from the kernel — cachedNow is refreshed only every
-	// 64 iterations, which could be 60+ms stale under bursty load.
-	// A stale now < dl comparison would spuriously re-arm a fresh
-	// 10s timer and effectively double the slowloris window. The
-	// fresh time.Now() costs one vDSO call, called only when a timer
-	// CQE arrives (rare in the hot path).
-	now = time.Now().UnixNano()
+	now := time.Now().UnixNano()
 	if now < dl {
 		// True early fire (kernel clock drift, very rare). Re-arm
 		// a fresh timer for the actual remaining time.

--- a/internal/conn/h1.go
+++ b/internal/conn/h1.go
@@ -38,13 +38,25 @@ func (s *H1State) ClearHeaderDeadline() {
 	s.HeaderDeadlineNs.Store(0)
 }
 
-// ArmHeaderDeadline rearms the slowloris-defence read-header deadline
-// to now + ReadHeaderTimeoutNs. Called by ProcessH1 when transitioning
-// from request-complete back to await-next-request state, and by the
-// engine at conn accept. No-op if ReadHeaderTimeoutNs == 0 (config
-// disabled or std-engine compat mode).
+// ArmHeaderDeadline arms the slowloris-defence read-header deadline
+// to now + ReadHeaderTimeoutNs. Called by:
+//   - the engine at conn accept (covers "client never sends a byte"),
+//   - ProcessH1 when it observes data arriving on a conn whose deadline
+//     was cleared (post-handler-idle keep-alive state).
+//
+// Idempotent: if HeaderDeadlineNs is already non-zero, this is a no-op
+// — the deadline is an ABSOLUTE budget for header completion, NOT
+// per-read. Resetting on every read would let a slow-drip client
+// extend the budget indefinitely (the bug this fix is meant to defeat).
+//
+// No-op if ReadHeaderTimeoutNs == 0 (config disabled or std-engine
+// compat mode).
 func (s *H1State) ArmHeaderDeadline() {
 	if s.ReadHeaderTimeoutNs == 0 {
+		return
+	}
+	if s.HeaderDeadlineNs.Load() != 0 {
+		// Already armed; don't reset (slowloris-bypass guard).
 		return
 	}
 	s.HeaderDeadlineNs.Store(timeNow().UnixNano() + s.ReadHeaderTimeoutNs)
@@ -309,21 +321,29 @@ func ProcessH1(ctx context.Context, data []byte, state *H1State, handler stream.
 		return nil
 	}
 
-	// Slowloris defence: clear the read-header deadline while we're
-	// actively parsing (we're not stuck waiting for headers). On
-	// return-nil (await more data) the deadline is rearmed for the
-	// next request — see the defer below. Errors / close / upgrade
-	// return paths intentionally leave the deadline cleared because
-	// the conn is about to be closed or handed off.
-	state.ClearHeaderDeadline()
-	defer func() {
-		if retErr == nil {
-			// ProcessH1 returns nil to signal "await more data". Arm
-			// the deadline so checkTimeouts closes a peer that drips
-			// bytes too slowly. No-op if ReadHeaderTimeout disabled.
-			state.ArmHeaderDeadline()
-		}
-	}()
+	// Slowloris defence — ReadHeaderTimeout state machine.
+	//
+	// Semantic: the deadline tracks the absolute time by which the
+	// current request's HEADERS must be fully received. It must NOT
+	// be confused with keep-alive idle (which IdleTimeout handles).
+	//
+	//   - conn-accept: engine arms once (covers "client never sends")
+	//   - ProcessH1 entry with data arriving on a request not yet in
+	//     body/parsed state, and deadline currently 0 (post-clear or
+	//     post-handler-idle): arm. Don't reset an already-armed
+	//     deadline — that would let a slow-drip client extend its
+	//     budget indefinitely.
+	//   - ParseRequest success (consumed > 0): clear. Body / handler /
+	//     keep-alive idle phases do NOT have a header deadline.
+	//
+	// Why entry-arm-if-zero (not entry-clear-then-defer-arm): the
+	// keep-alive idle window between requests must NOT count against
+	// ReadHeaderTimeout. With defer-arm, every successful request
+	// would re-arm the deadline; the next keep-alive idle conn would
+	// get killed at ReadHeaderTimeout instead of IdleTimeout.
+	if state.HeaderDeadlineNs.Load() == 0 && state.bodyNeeded == 0 && !state.Detached {
+		state.ArmHeaderDeadline()
+	}
 
 	// In-progress fixed-length body spanning multiple reads. Append into
 	// the dedicated bodyBuf (no state.buffer memcpy), then re-parse the
@@ -347,6 +367,9 @@ func ProcessH1(ctx context.Context, data []byte, state *H1State, handler stream.
 			writeErrorResponse(write, 400, "Bad Request")
 			return err
 		}
+		// Headers complete (this is a re-parse from buffer, so the
+		// original parse already succeeded — clear is idempotent).
+		state.ClearHeaderDeadline()
 		state.buffer.Reset()
 		bodyData := state.bodyBuf
 		if err := tryUpgradeH2C(state, bodyData, rest, write); err != nil {
@@ -386,6 +409,11 @@ func ProcessH1(ctx context.Context, data []byte, state *H1State, handler stream.
 				state.buffer.Write(data[offset:])
 				return nil
 			}
+			// Headers complete — clear the slowloris deadline. The
+			// body / handler / keep-alive idle that follow are NOT
+			// header-deadline-eligible. Re-arm happens at the next
+			// ProcessH1 entry that observes deadline == 0.
+			state.ClearHeaderDeadline()
 
 			bodyNeeded := int64(0)
 			if state.req.ChunkedEncoding {
@@ -506,6 +534,9 @@ func ProcessH1(ctx context.Context, data []byte, state *H1State, handler stream.
 		if consumed == 0 {
 			break
 		}
+		// Headers complete — clear the slowloris deadline. See the
+		// state-machine comment at the top of ProcessH1.
+		state.ClearHeaderDeadline()
 
 		bodyNeeded := int64(0)
 		if state.req.ChunkedEncoding {

--- a/internal/conn/h1.go
+++ b/internal/conn/h1.go
@@ -8,11 +8,16 @@ import (
 	"fmt"
 	"net"
 	"sync/atomic"
+	"time"
 
 	"github.com/goceleris/celeris/internal/ctxkit"
 	h1 "github.com/goceleris/celeris/protocol/h1"
 	"github.com/goceleris/celeris/protocol/h2/stream"
 )
+
+// timeNow is a package-level alias so tests can stub the clock when
+// exercising the read-header-deadline path. Production = time.Now.
+var timeNow = time.Now
 
 func init() {
 	// Wire the H1-package helpers so protocol/h2/stream can lazily
@@ -24,6 +29,26 @@ func init() {
 // ErrHijacked is returned by ProcessH1 when the connection was hijacked.
 // The engine must not close or reuse the FD after receiving this error.
 var ErrHijacked = errors.New("celeris: connection hijacked")
+
+// ClearHeaderDeadline drops the slowloris-defence read-header deadline
+// — called after a successful ParseRequest signals that the next state
+// is request handling, not header reading. The engine's checkTimeouts
+// sweep treats 0 as "no deadline" and skips the check.
+func (s *H1State) ClearHeaderDeadline() {
+	s.HeaderDeadlineNs.Store(0)
+}
+
+// ArmHeaderDeadline rearms the slowloris-defence read-header deadline
+// to now + ReadHeaderTimeoutNs. Called by ProcessH1 when transitioning
+// from request-complete back to await-next-request state, and by the
+// engine at conn accept. No-op if ReadHeaderTimeoutNs == 0 (config
+// disabled or std-engine compat mode).
+func (s *H1State) ArmHeaderDeadline() {
+	if s.ReadHeaderTimeoutNs == 0 {
+		return
+	}
+	s.HeaderDeadlineNs.Store(timeNow().UnixNano() + s.ReadHeaderTimeoutNs)
+}
 
 // errConnectionClose is returned when the client requests Connection: close.
 // Pre-allocated to avoid per-request fmt.Errorf allocation.
@@ -101,6 +126,26 @@ type H1State struct {
 	// the engine's idle sweep checks it on detached connections. 0 = no
 	// deadline.
 	IdleDeadlineNs atomic.Int64
+
+	// HeaderDeadlineNs holds the absolute deadline (Unix nanoseconds) by
+	// which the next request's headers must be fully received, or the
+	// engine must close the connection. This is the canonical slowloris
+	// defence on the iouring + epoll engines (std wires the equivalent
+	// via http.Server.ReadHeaderTimeout). Set by the engine at conn-
+	// accept and after each successful request parse (so the next
+	// pipelined / keep-alive request gets a fresh budget). Cleared when
+	// ProcessH1 returns having fully parsed a request. 0 = no deadline
+	// (e.g. -1 in config explicitly disables; ReadHeaderTimeout was
+	// otherwise unenforced on iouring + epoll prior to celeris v1.4.11).
+	HeaderDeadlineNs atomic.Int64
+
+	// ReadHeaderTimeoutNs is the configured ReadHeaderTimeout in
+	// nanoseconds, supplied by the engine at initProtocol. Used by
+	// ProcessH1 to re-arm HeaderDeadlineNs after each request parse —
+	// keeps the deadline logic local to where it matters (the parsing
+	// loop) without ProcessH1 needing access to the engine's *cfg.
+	// 0 = no header deadline (config disabled).
+	ReadHeaderTimeoutNs int64
 
 	// EnableH2Upgrade, when true, permits this connection to honor a
 	// valid RFC 7540 §3.2 h2c upgrade request. Set by the engine at
@@ -254,7 +299,7 @@ func CloseH1(state *H1State) {
 // ProcessH1 processes incoming H1 data, parsing requests and calling the handler.
 // The write callback is used to send response bytes back to the connection.
 func ProcessH1(ctx context.Context, data []byte, state *H1State, handler stream.Handler,
-	write func([]byte)) error {
+	write func([]byte)) (retErr error) {
 
 	// WebSocket upgrade: deliver raw bytes to the middleware goroutine
 	// instead of parsing as H1. The delivery callback writes to an io.Pipe
@@ -263,6 +308,22 @@ func ProcessH1(ctx context.Context, data []byte, state *H1State, handler stream.
 		state.WSDataDelivery(data)
 		return nil
 	}
+
+	// Slowloris defence: clear the read-header deadline while we're
+	// actively parsing (we're not stuck waiting for headers). On
+	// return-nil (await more data) the deadline is rearmed for the
+	// next request — see the defer below. Errors / close / upgrade
+	// return paths intentionally leave the deadline cleared because
+	// the conn is about to be closed or handed off.
+	state.ClearHeaderDeadline()
+	defer func() {
+		if retErr == nil {
+			// ProcessH1 returns nil to signal "await more data". Arm
+			// the deadline so checkTimeouts closes a peer that drips
+			// bytes too slowly. No-op if ReadHeaderTimeout disabled.
+			state.ArmHeaderDeadline()
+		}
+	}()
 
 	// In-progress fixed-length body spanning multiple reads. Append into
 	// the dedicated bodyBuf (no state.buffer memcpy), then re-parse the

--- a/internal/conn/h1.go
+++ b/internal/conn/h1.go
@@ -60,6 +60,11 @@ func (s *H1State) ArmHeaderDeadline() {
 		return
 	}
 	s.HeaderDeadlineNs.Store(timeNow().UnixNano() + s.ReadHeaderTimeoutNs)
+	// Notify the engine so it can submit a kernel-enforced timer
+	// (iouring IORING_OP_TIMEOUT SQE) — see field docstring.
+	if s.OnHeaderDeadlineArmed != nil {
+		s.OnHeaderDeadlineArmed()
+	}
 }
 
 // errConnectionClose is returned when the client requests Connection: close.
@@ -158,6 +163,17 @@ type H1State struct {
 	// loop) without ProcessH1 needing access to the engine's *cfg.
 	// 0 = no header deadline (config disabled).
 	ReadHeaderTimeoutNs int64
+
+	// OnHeaderDeadlineArmed is invoked synchronously by ArmHeaderDeadline
+	// whenever the deadline transitions from 0 → armed. The iouring
+	// engine sets this to submit an IORING_OP_TIMEOUT SQE so the kernel
+	// closes the conn at the deadline regardless of sweep cadence. The
+	// epoll engine leaves it nil (uses per-worker timerfd instead). nil
+	// = no-op.
+	//
+	// The callback runs on the engine's worker thread (ProcessH1's
+	// caller). It MUST NOT block — SQE submission only.
+	OnHeaderDeadlineArmed func()
 
 	// EnableH2Upgrade, when true, permits this connection to honor a
 	// valid RFC 7540 §3.2 h2c upgrade request. Set by the engine at

--- a/internal/conn/h1_test.go
+++ b/internal/conn/h1_test.go
@@ -2,9 +2,64 @@ package conn
 
 import (
 	"testing"
+	"time"
 
 	"github.com/goceleris/celeris/protocol/h1"
 )
+
+// TestHeaderDeadline_ClearArmCycle pins the v1.4.11 slowloris-defence
+// state machine for iouring + epoll. Pre-fix neither engine enforced
+// ReadHeaderTimeout (only std did, via http.Server). The state machine:
+//
+//   1. Engine sets ReadHeaderTimeoutNs + ArmHeaderDeadline at conn-
+//      accept. HeaderDeadlineNs is now > 0.
+//   2. ProcessH1 calls ClearHeaderDeadline at its entry (we're
+//      actively parsing, not waiting). HeaderDeadlineNs == 0.
+//   3. ProcessH1's deferred ArmHeaderDeadline fires on return-nil
+//      (awaiting next request's bytes). HeaderDeadlineNs > 0 again.
+//   4. If ReadHeaderTimeoutNs is 0 (config disabled), all arm calls
+//      are no-ops.
+//
+// checkTimeouts in each engine closes the conn when now > deadline.
+func TestHeaderDeadline_ClearArmCycle(t *testing.T) {
+	s := NewH1State()
+	s.ReadHeaderTimeoutNs = int64(10 * time.Second)
+
+	// Arm — deadline should be ~10s in the future.
+	before := time.Now().UnixNano()
+	s.ArmHeaderDeadline()
+	after := time.Now().UnixNano()
+	dl := s.HeaderDeadlineNs.Load()
+	if dl < before+s.ReadHeaderTimeoutNs || dl > after+s.ReadHeaderTimeoutNs {
+		t.Errorf("ArmHeaderDeadline: dl=%d not in [%d, %d]",
+			dl, before+s.ReadHeaderTimeoutNs, after+s.ReadHeaderTimeoutNs)
+	}
+
+	// Clear — deadline should be 0.
+	s.ClearHeaderDeadline()
+	if dl := s.HeaderDeadlineNs.Load(); dl != 0 {
+		t.Errorf("ClearHeaderDeadline: dl=%d, want 0", dl)
+	}
+
+	// Re-arm — back to a future deadline.
+	s.ArmHeaderDeadline()
+	if dl := s.HeaderDeadlineNs.Load(); dl <= 0 {
+		t.Errorf("Re-ArmHeaderDeadline: dl=%d, want positive", dl)
+	}
+}
+
+// TestHeaderDeadline_DisabledNoArm verifies the no-op behaviour when
+// ReadHeaderTimeoutNs is 0 (config disabled via -1 or omitted on a
+// custom build that doesn't set a default). ArmHeaderDeadline must
+// leave HeaderDeadlineNs at 0 so checkTimeouts skips the check.
+func TestHeaderDeadline_DisabledNoArm(t *testing.T) {
+	s := NewH1State()
+	s.ReadHeaderTimeoutNs = 0 // disabled
+	s.ArmHeaderDeadline()
+	if dl := s.HeaderDeadlineNs.Load(); dl != 0 {
+		t.Errorf("ArmHeaderDeadline with disabled config must be no-op, got dl=%d", dl)
+	}
+}
 
 func TestH1StateMaxBodySize(t *testing.T) {
 	s := NewH1State()

--- a/internal/conn/h1_test.go
+++ b/internal/conn/h1_test.go
@@ -61,6 +61,61 @@ func TestHeaderDeadline_DisabledNoArm(t *testing.T) {
 	}
 }
 
+// TestHeaderDeadline_ArmIdempotent pins the slowloris-bypass guard:
+// calling ArmHeaderDeadline twice MUST NOT advance the deadline. The
+// budget is absolute (from "first byte arrives" to "headers complete"),
+// not per-read. Without this guard a slow-drip client could call into
+// the engine (re-trigger ProcessH1's entry-arm) every few hundred ms
+// and indefinitely extend the budget.
+func TestHeaderDeadline_ArmIdempotent(t *testing.T) {
+	s := NewH1State()
+	s.ReadHeaderTimeoutNs = int64(10 * time.Second)
+
+	s.ArmHeaderDeadline()
+	first := s.HeaderDeadlineNs.Load()
+	if first == 0 {
+		t.Fatal("first ArmHeaderDeadline must arm")
+	}
+
+	// Sleep a bit so re-arming would observably shift the deadline.
+	time.Sleep(20 * time.Millisecond)
+
+	s.ArmHeaderDeadline() // must be no-op while already armed
+	second := s.HeaderDeadlineNs.Load()
+	if second != first {
+		t.Errorf("re-arm without clear must NOT shift deadline: first=%d second=%d (drift=%dns)",
+			first, second, second-first)
+	}
+}
+
+// TestHeaderDeadline_KeepAliveIdleNotKilled is the regression test for
+// the subtle bug caught during the v1.4.11 implementation review: my
+// earlier "defer arm on return-nil" design would have re-armed the
+// deadline at the end of EVERY successful request. The conn then enters
+// keep-alive idle (waiting for the next request), and 10s later
+// checkTimeouts would close it — killing the conn at ReadHeaderTimeout
+// instead of IdleTimeout.
+//
+// Correct semantic: after ClearHeaderDeadline (called when headers are
+// parsed), the deadline stays 0 through body / handler / keep-alive
+// idle. It only re-arms when the NEXT request's first byte arrives
+// (ProcessH1 entry observes deadline == 0 and arms).
+//
+// This test simulates: arm → clear → simulate idle window → confirm
+// the deadline is still 0 (NOT something we'd push past).
+func TestHeaderDeadline_KeepAliveIdleNotKilled(t *testing.T) {
+	s := NewH1State()
+	s.ReadHeaderTimeoutNs = int64(10 * time.Second)
+
+	s.ArmHeaderDeadline() // conn-accept arm
+	s.ClearHeaderDeadline() // headers parsed
+	// Simulate keep-alive idle window. checkTimeouts sees deadline==0
+	// → skips the check. IdleTimeout takes over (different code path).
+	if dl := s.HeaderDeadlineNs.Load(); dl != 0 {
+		t.Errorf("after clear, keep-alive idle must observe deadline=0, got %d", dl)
+	}
+}
+
 func TestH1StateMaxBodySize(t *testing.T) {
 	s := NewH1State()
 

--- a/internal/conn/h1_test.go
+++ b/internal/conn/h1_test.go
@@ -11,14 +11,14 @@ import (
 // state machine for iouring + epoll. Pre-fix neither engine enforced
 // ReadHeaderTimeout (only std did, via http.Server). The state machine:
 //
-//   1. Engine sets ReadHeaderTimeoutNs + ArmHeaderDeadline at conn-
-//      accept. HeaderDeadlineNs is now > 0.
-//   2. ProcessH1 calls ClearHeaderDeadline at its entry (we're
-//      actively parsing, not waiting). HeaderDeadlineNs == 0.
-//   3. ProcessH1's deferred ArmHeaderDeadline fires on return-nil
-//      (awaiting next request's bytes). HeaderDeadlineNs > 0 again.
-//   4. If ReadHeaderTimeoutNs is 0 (config disabled), all arm calls
-//      are no-ops.
+//  1. Engine sets ReadHeaderTimeoutNs + ArmHeaderDeadline at conn-
+//     accept. HeaderDeadlineNs is now > 0.
+//  2. ProcessH1 calls ClearHeaderDeadline at its entry (we're
+//     actively parsing, not waiting). HeaderDeadlineNs == 0.
+//  3. ProcessH1's deferred ArmHeaderDeadline fires on return-nil
+//     (awaiting next request's bytes). HeaderDeadlineNs > 0 again.
+//  4. If ReadHeaderTimeoutNs is 0 (config disabled), all arm calls
+//     are no-ops.
 //
 // checkTimeouts in each engine closes the conn when now > deadline.
 func TestHeaderDeadline_ClearArmCycle(t *testing.T) {
@@ -107,7 +107,7 @@ func TestHeaderDeadline_KeepAliveIdleNotKilled(t *testing.T) {
 	s := NewH1State()
 	s.ReadHeaderTimeoutNs = int64(10 * time.Second)
 
-	s.ArmHeaderDeadline() // conn-accept arm
+	s.ArmHeaderDeadline()   // conn-accept arm
 	s.ClearHeaderDeadline() // headers parsed
 	// Simulate keep-alive idle window. checkTimeouts sees deadline==0
 	// → skips the check. IdleTimeout takes over (different code path).

--- a/middleware/recovery/recovery.go
+++ b/middleware/recovery/recovery.go
@@ -37,6 +37,25 @@ var stackPool = sync.Pool{New: func() any {
 }}
 
 // New creates a recovery middleware with the given config.
+//
+// Performance note: by default `cfg.Logger` falls back to `slog.Default()`,
+// which on most Go programs is the stdlib text-handler writing to
+// `os.Stderr`. Stderr writes serialize on a global mutex inside Go's
+// default handler. Under iouring/epoll's async-dispatch model the
+// dispatch goroutine holds `cs.detachMu` across the `ProcessH1` call,
+// so a synchronous `log.LogAttrs` here will gate the worker thread for
+// the duration of the stderr write — sustained panic loads can drop
+// engine throughput by an order of magnitude (~14×) and let
+// slowloris-defence header-deadlines slip past on concurrent conns.
+// If your handlers can panic at >100 req/sec (recovery middleware is
+// usually the only thing standing between a buggy handler and a
+// process crash), pass an explicit non-blocking Logger:
+//
+//	slog.New(slog.NewTextHandler(io.Discard, nil))  // drop logs
+//	slog.New(myAsyncHandler)                        // async sink
+//
+// or initialize `slog.SetDefault(...)` to a non-blocking handler at
+// process startup.
 func New(config ...Config) celeris.HandlerFunc {
 	cfg := defaultConfig
 	if len(config) > 0 {

--- a/test/integration/slowloris_synthetic_test.go
+++ b/test/integration/slowloris_synthetic_test.go
@@ -1,0 +1,318 @@
+//go:build linux
+
+package integration
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/goceleris/celeris/engine"
+	"github.com/goceleris/celeris/engine/epoll"
+	"github.com/goceleris/celeris/engine/iouring"
+	"github.com/goceleris/celeris/resource"
+)
+
+// TestSlowlorisSynthetic is the focused per-engine reproducer for the
+// v1.4.11 slowloris-defence work. Replaces the 1h+ probatorium nightly
+// cycle with an in-process test that logs every relevant step.
+//
+// Scenario per engine:
+//
+//  1. Start celeris with engine=iouring/epoll/std, ReadHeaderTimeout=2s
+//     (short so the test finishes fast).
+//  2. Open a raw TCP client conn.
+//  3. Send a partial HTTP/1.1 request preamble (no terminating \r\n\r\n).
+//  4. Drip 'X' bytes every 200ms.
+//  5. Record the FIRST write failure timestamp and which error it returned.
+//  6. Compare actual close time to expected (~2s).
+//
+// Expected: each engine MUST close the conn at ~ReadHeaderTimeout, and
+// the client MUST observe the close on its next write within reasonable
+// slack (~500ms typical TCP-FIN-delivery latency).
+//
+// Failure modes the test logs explicitly:
+//   - Close never observed within timeout (defence not firing).
+//   - Close observed but much later than ReadHeaderTimeout (cadence issue).
+//   - Close at deadline but client write succeeds for seconds after
+//     (FIN-vs-RST issue — RST would force immediate fail).
+func TestSlowlorisSynthetic(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		newEng  func(cfg resource.Config) (engine.Engine, error)
+		minSkip string // skip message if engine unsupported
+	}{
+		{
+			name: "iouring",
+			newEng: func(cfg resource.Config) (engine.Engine, error) {
+				return iouring.New(cfg, &echoHandler{})
+			},
+		},
+		{
+			name: "epoll",
+			newEng: func(cfg resource.Config) (engine.Engine, error) {
+				return epoll.New(cfg, &echoHandler{})
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := resource.Config{
+				Addr:              "127.0.0.1:0",
+				Protocol:          engine.HTTP1,
+				ReadHeaderTimeout: 2 * time.Second, // tight so the test is fast
+				ReadTimeout:       30 * time.Second,
+				WriteTimeout:      30 * time.Second,
+				IdleTimeout:       120 * time.Second,
+				Logger:            nil,
+			}
+			eng, err := tc.newEng(cfg)
+			if err != nil {
+				if tc.minSkip != "" {
+					t.Skip(tc.minSkip)
+				}
+				t.Skipf("%s engine unavailable on this host: %v", tc.name, err)
+			}
+			startEngine(t, eng)
+
+			ag, ok := eng.(addrGetter)
+			if !ok {
+				t.Fatalf("%s engine has no Addr()", tc.name)
+			}
+			addr := ag.Addr().String()
+			t.Logf("[%s] server listening on %s, ReadHeaderTimeout=%v", tc.name, addr, cfg.ReadHeaderTimeout)
+
+			// Client phase.
+			dial := net.Dialer{Timeout: 2 * time.Second}
+			conn, err := dial.Dial("tcp", addr)
+			if err != nil {
+				t.Fatalf("dial: %v", err)
+			}
+			defer func() { _ = conn.Close() }()
+
+			// Preamble: partial headers, no \r\n\r\n.
+			preamble := []byte("GET / HTTP/1.1\r\nHost: test\r\nX-Drip: ")
+			if _, err := conn.Write(preamble); err != nil {
+				t.Fatalf("preamble write: %v", err)
+			}
+			t.Logf("[%s] preamble sent (%d bytes)", tc.name, len(preamble))
+
+			startWall := time.Now()
+			// Drip 'X' every 200ms for up to 12 * ReadHeaderTimeout — well
+			// beyond the budget so a misfire is obvious.
+			dripDeadline := time.After(12 * cfg.ReadHeaderTimeout)
+			ticker := time.NewTicker(200 * time.Millisecond)
+			defer ticker.Stop()
+
+			var (
+				closeObservedAt time.Time
+				closeErr        error
+				writeCount      int
+			)
+		drip:
+			for {
+				select {
+				case <-dripDeadline:
+					t.Logf("[%s] drip deadline reached after %v WITHOUT close — defence FAILED", tc.name, time.Since(startWall))
+					break drip
+				case <-ticker.C:
+					writeCount++
+					n, err := conn.Write([]byte("X"))
+					elapsed := time.Since(startWall)
+					if err != nil {
+						closeObservedAt = time.Now()
+						closeErr = err
+						t.Logf("[%s] write #%d at %.2fs FAILED: %v (n=%d) — close observed", tc.name, writeCount, elapsed.Seconds(), err, n)
+						break drip
+					}
+					if writeCount%5 == 0 {
+						t.Logf("[%s] write #%d at %.2fs ok", tc.name, writeCount, elapsed.Seconds())
+					}
+				}
+			}
+
+			if closeObservedAt.IsZero() {
+				t.Fatalf("[%s] DEFENCE FAILED: client wrote %d bytes over %v without close", tc.name, writeCount, time.Since(startWall))
+			}
+			closeLatency := closeObservedAt.Sub(startWall)
+			slack := closeLatency - cfg.ReadHeaderTimeout
+			t.Logf("[%s] DEFENCE FIRED at %.2fs (slack vs %v deadline: %v); err=%v",
+				tc.name, closeLatency.Seconds(), cfg.ReadHeaderTimeout, slack, closeErr)
+
+			// Assertion: close must fire within deadline + 2s slack.
+			// This matches what the probatorium walker expects (12s budget
+			// for a 10s deadline = 2s slack window).
+			if slack > 2*time.Second {
+				t.Errorf("[%s] close fired %v AFTER ReadHeaderTimeout — outside 2s slack window (probatorium walker would record a hang here)",
+					tc.name, slack)
+			}
+		})
+	}
+}
+
+// _ keeps the package compilable when celeris.New is the only consumer
+// of these imports in the wider integration test surface.
+var _ = fmt.Sprintf
+
+// TestSlowlorisSyntheticConcurrent exercises the high-load condition
+// probatorium hits: many simultaneous slowloris conns competing with
+// non-slowloris background traffic. The synthetic single-client test
+// (TestSlowlorisSynthetic) proves the defence works in isolation;
+// THIS test probes whether it still fires reliably when the worker is
+// busy with concurrent traffic — replicating what causes the 11%
+// residual hang rate in the matrix nightly.
+//
+// Pattern:
+//   - 1 server (per engine), short ReadHeaderTimeout (2s).
+//   - N slowloris clients, all starting roughly simultaneously.
+//   - M background clients doing fast successful requests.
+//   - Each slowloris client measures its own close-observed-at time.
+//   - Assertion: ALL N slowloris clients must observe close within
+//     slack of ReadHeaderTimeout.
+func TestSlowlorisSyntheticConcurrent(t *testing.T) {
+	const (
+		nSlowloris  = 64  // simultaneous slowloris attempts (probatorium fires many)
+		nBackground = 200 // simultaneous fast clients (probatorium Markov walkers)
+		readHdrTO   = 2 * time.Second
+		slackBudget = 2 * time.Second // walker-style budget over the deadline
+	)
+	for _, tc := range []struct {
+		name   string
+		newEng func(cfg resource.Config) (engine.Engine, error)
+	}{
+		{
+			name: "iouring",
+			newEng: func(cfg resource.Config) (engine.Engine, error) {
+				return iouring.New(cfg, &echoHandler{})
+			},
+		},
+		{
+			name: "epoll",
+			newEng: func(cfg resource.Config) (engine.Engine, error) {
+				return epoll.New(cfg, &echoHandler{})
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := resource.Config{
+				Addr:              "127.0.0.1:0",
+				Protocol:          engine.HTTP1,
+				ReadHeaderTimeout: readHdrTO,
+				ReadTimeout:       30 * time.Second,
+				WriteTimeout:      30 * time.Second,
+				IdleTimeout:       120 * time.Second,
+				// Match probatorium refapp config: async dispatch pre-
+				// allocates detachMu on every conn, forcing the close
+				// path through finishCloseDetached (graceful close with
+				// drain). This is the shape that produced 11% residual
+				// hangs in the matrix nightly.
+				AsyncHandlers: true,
+			}
+			eng, err := tc.newEng(cfg)
+			if err != nil {
+				t.Skipf("%s engine unavailable: %v", tc.name, err)
+			}
+			startEngine(t, eng)
+			addr := eng.(addrGetter).Addr().String()
+			t.Logf("[%s] server listening on %s", tc.name, addr)
+
+			// Background traffic — simulates Markov walkers hammering the
+			// server with successful requests. Drives the worker's CQE
+			// rate high so the slowloris-conn timer SQE has to compete
+			// for SQ ring space and CQE dispatch attention.
+			bgDone := make(chan struct{})
+			defer close(bgDone)
+			for i := 0; i < nBackground; i++ {
+				go func() {
+					for {
+						select {
+						case <-bgDone:
+							return
+						default:
+						}
+						c, err := net.DialTimeout("tcp", addr, time.Second)
+						if err != nil {
+							time.Sleep(10 * time.Millisecond)
+							continue
+						}
+						_, _ = c.Write([]byte("GET / HTTP/1.1\r\nHost: bg\r\n\r\n"))
+						_ = c.SetReadDeadline(time.Now().Add(time.Second))
+						_, _ = c.Read(make([]byte, 256))
+						_ = c.Close()
+					}
+				}()
+			}
+			// Let background traffic ramp up briefly so the worker is
+			// already busy when the slowloris cohort starts.
+			time.Sleep(200 * time.Millisecond)
+
+			type result struct {
+				idx             int
+				closeObservedAt time.Duration
+				err             error
+				writesSucceeded int
+			}
+			results := make(chan result, nSlowloris)
+
+			startBarrier := make(chan struct{})
+			for i := 0; i < nSlowloris; i++ {
+				go func(idx int) {
+					<-startBarrier
+					conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+					if err != nil {
+						results <- result{idx: idx, err: err}
+						return
+					}
+					defer func() { _ = conn.Close() }()
+					_, _ = conn.Write([]byte("GET / HTTP/1.1\r\nHost: t\r\nX-Drip: "))
+					start := time.Now()
+					ticker := time.NewTicker(200 * time.Millisecond)
+					defer ticker.Stop()
+					budget := time.After(readHdrTO + slackBudget + time.Second)
+					writes := 0
+					for {
+						select {
+						case <-budget:
+							results <- result{idx: idx, err: fmt.Errorf("DEFENCE-FAIL: budget exceeded, %d writes succeeded", writes), writesSucceeded: writes}
+							return
+						case <-ticker.C:
+							writes++
+							if _, err := conn.Write([]byte("X")); err != nil {
+								results <- result{idx: idx, closeObservedAt: time.Since(start), writesSucceeded: writes}
+								return
+							}
+						}
+					}
+				}(i)
+			}
+			close(startBarrier)
+
+			var (
+				ok, failed int
+				maxClose   time.Duration
+				latencies  []time.Duration
+			)
+			for i := 0; i < nSlowloris; i++ {
+				r := <-results
+				if r.err != nil {
+					failed++
+					t.Logf("[%s] client #%d FAILED: %v (writes=%d)", tc.name, r.idx, r.err, r.writesSucceeded)
+					continue
+				}
+				ok++
+				latencies = append(latencies, r.closeObservedAt)
+				if r.closeObservedAt > maxClose {
+					maxClose = r.closeObservedAt
+				}
+			}
+			t.Logf("[%s] %d clients defended, %d failed; max close-latency=%v (deadline=%v slack=%v)",
+				tc.name, ok, failed, maxClose, readHdrTO, slackBudget)
+			if failed > 0 {
+				t.Errorf("[%s] %d/%d clients NOT defended within %v slack", tc.name, failed, nSlowloris, slackBudget)
+			}
+			if maxClose > readHdrTO+slackBudget {
+				t.Errorf("[%s] worst close-latency %v exceeded %v slack — probatorium walker would record a hang", tc.name, maxClose, slackBudget)
+			}
+		})
+	}
+}

--- a/test/integration/slowloris_synthetic_test.go
+++ b/test/integration/slowloris_synthetic_test.go
@@ -288,9 +288,10 @@ func TestSlowlorisSyntheticConcurrent(t *testing.T) {
 			close(startBarrier)
 
 			var (
-				ok, failed int
-				maxClose   time.Duration
-				latencies  []time.Duration
+				ok, failed   int
+				maxClose     time.Duration
+				latencySum   time.Duration
+				latencyCount int
 			)
 			for i := 0; i < nSlowloris; i++ {
 				r := <-results
@@ -300,11 +301,17 @@ func TestSlowlorisSyntheticConcurrent(t *testing.T) {
 					continue
 				}
 				ok++
-				latencies = append(latencies, r.closeObservedAt)
+				latencySum += r.closeObservedAt
+				latencyCount++
 				if r.closeObservedAt > maxClose {
 					maxClose = r.closeObservedAt
 				}
 			}
+			var avgClose time.Duration
+			if latencyCount > 0 {
+				avgClose = latencySum / time.Duration(latencyCount)
+			}
+			t.Logf("[%s] avg close-latency=%v across %d defended clients", tc.name, avgClose, latencyCount)
 			t.Logf("[%s] %d clients defended, %d failed; max close-latency=%v (deadline=%v slack=%v)",
 				tc.name, ok, failed, maxClose, readHdrTO, slackBudget)
 			if failed > 0 {


### PR DESCRIPTION
## Summary

Replaces #292 (sweep-only) and #293 (sweep-tightened). v1.4.11 candidate. Adds **kernel-enforced per-conn header deadline** on iouring via IORING_OP_TIMEOUT SQEs. The kernel fires the timer at exactly the deadline regardless of CQE traffic — eliminating the sweep-cadence dependency that capped previous attempts at 56% reduction.

## Journey

| Attempt | Approach | Reduction |
|---|---|---:|
| PR #292 | H1State state machine + sweep-based check | **45%** |
| PR #293 | + cadence tightening (gate 0x1F, maxWait 25ms) | **56%** |
| **PR #294** (this) | **per-conn IORING_OP_TIMEOUT SQE** | target: **~100%** |

Root cause of the sweep-based ceiling: under SO_REUSEPORT-distributed conns, some slowloris attempts land on workers with low CQE traffic; sweep cadence is bounded by `gate × adaptive_wait_time`, which can stretch to seconds when other conns on that worker are also idle.

## Design

- **opTIMEOUT (11) / opTIMEOUTREMOVE (12)** opcodes added (kernel 5.4+).
- **udHeaderTimer** user_data tag added.
- **prepTimeout** SQE helper accepts a kernelTimespec pointer.
- **connState** gains \`headerTimerSpec\` (re-used kernelTimespec, owned by the conn so SQE memory stays valid until kernel reads it) + \`headerTimerArmed\` flag (avoids duplicate SQEs).
- **H1State** gains \`OnHeaderDeadlineArmed\` callback hook. \`ArmHeaderDeadline\` invokes it on the 0→armed transition; engine submits a fresh SQE.
- **Engine initProtocol** wires the callback to \`w.armHeaderTimer\`; calls it once at conn-accept (initial arm).
- **CQE dispatch** routes \`udHeaderTimer\` to \`w.handleHeaderTimer\` which checks HeaderDeadlineNs (race-free against ClearHeaderDeadline) and closes the conn if the deadline really has expired.

## Race correctness

| Scenario | Behavior |
|---|---|
| Timer CQE arrives, headers parsed (ClearHeaderDeadline ran) | Sees HeaderDeadlineNs == 0, no-op |
| Spurious early fire (clock drift) | Re-submits fresh timer for current deadline |
| Re-arm during in-flight timer | ArmHeaderDeadline idempotent; in-flight timer's CQE checks state on fire |
| Conn close during in-flight timer | handleHeaderTimer checks \`cs.closing\`, returns early |

Single timer per conn at any time guaranteed by \`headerTimerArmed\` flag.

## What this does NOT change

- epoll engine: still uses the sweep-based defence (per-conn timerfd would double fd usage — not worth it for the bounded improvement). Expected slightly higher residual hangs on epoll cells than iouring.

## Tests

All 4 cherry-picked unit tests still pass:
- TestHeaderDeadline_ClearArmCycle
- TestHeaderDeadline_DisabledNoArm
- TestHeaderDeadline_ArmIdempotent
- TestHeaderDeadline_KeepAliveIdleNotKilled

Full \`go test ./...\` clean. \`GOOS=linux go build\` clean. \`go vet\` clean.

## Empirical verification path

Probatorium nightly + 24h soak against this branch's SHA. Expect:
- **iouring** \`adv_hang_until_timeout\` → ~0 (target)
- **epoll** \`adv_hang_until_timeout\` → improvement but possibly not 0
- **std** unchanged at 0
- Bug oracles (properties_failed, adv_wrong_accepted, h2c_crashed, seeds_*) stay 0
- No keep-alive regression (transport_err must not spike)

**Will not propose v1.4.11 tag until nightly + soak confirm iouring at ~0 hangs.**