### PR TITLE
chore(ci): add actionlint to the Lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,13 @@ jobs:
         with:
           version: v2.9
           working-directory: middleware/protobuf
+      - name: actionlint
+        # Workflow-YAML lint: catches script-injection vectors, unknown
+        # runner labels, malformed shell, action input misuse — the
+        # whole class golangci-lint can't see.
+        run: |
+          go install github.com/rhysd/actionlint/cmd/actionlint@latest
+          actionlint -color
 
   unit:
     name: Unit (root + middleware sub-modules)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,9 +86,10 @@ jobs:
       # msr1 + Multipass and is exercised end-to-end by the
       # autobahn-fuzzingclient test under `mage testAutobahn`.
       - name: Root module — race tests (excluding test/ + adaptive/ + websocket)
-        run: >-
-          go test -race -count=1 -timeout=300s
-          $(go list ./... | grep -vE '/test/|/adaptive($|/)|/middleware/websocket($|/)')
+        run: |
+          pkgs=$(go list ./... | grep -vE '/test/|/adaptive($|/)|/middleware/websocket($|/)')
+          # shellcheck disable=SC2086  # word-splitting is intentional — `go test` wants one package per arg
+          go test -race -count=1 -timeout=300s $pkgs
       - name: middleware/compress
         run: go test -race -count=1 -timeout=120s ./...
         working-directory: middleware/compress

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -389,7 +389,7 @@ jobs:
       - name: Start sentinel stack
         run: |
           docker compose -f test/conformance/redis/docker-compose.sentinel.yml up -d
-          for i in $(seq 1 60); do
+          for _ in $(seq 1 60); do
             if docker exec celeris-sentinel-1 redis-cli -p 26379 \
                 sentinel master mymaster 2>/dev/null | grep -q "^127.0.0.1$"; then
               echo "sentinels ready"


### PR DESCRIPTION
Adds actionlint to the existing Lint job so this repo's own GitHub Actions YAML is sanity-checked on every PR — script-injection vectors, unknown runner labels, malformed shell, action input misuse. ~5s overhead, uses the same checkout + setup-go that already runs.