### PR TITLE
fix(epoll): don't unlock detachMu on the inline per-handler-async path (WS/SSE crash)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
       - name: Lint root module
         uses: golangci/golangci-lint-action@v9
         with:
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
       # Excludes ./test/... to keep this job deterministic — those
       # suites (integration, spec, perfmatrix, sustainedload) are
       # timing-sensitive on shared GitHub Actions runners and live in
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
       - name: Conformance matrix (engines × protocols)
         run: go test -v -race -count=1 -timeout=120s ./test/conformance/...
 
@@ -139,7 +139,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
       - name: Postgres conformance
         run: >-
           go test -tags postgres -race -count=1 -timeout=300s
@@ -159,7 +159,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
       - name: Build root module
         run: go build ./...
       - name: Build middleware/compress
@@ -182,7 +182,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Root module

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,26 +31,26 @@ jobs:
       - name: Lint root module
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.9
+          version: v2.12
       - name: Lint middleware/compress
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.9
+          version: v2.12
           working-directory: middleware/compress
       - name: Lint middleware/metrics
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.9
+          version: v2.12
           working-directory: middleware/metrics
       - name: Lint middleware/otel
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.9
+          version: v2.12
           working-directory: middleware/otel
       - name: Lint middleware/protobuf
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.9
+          version: v2.12
           working-directory: middleware/protobuf
 
   unit:

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
       - name: Conformance
         run: >-
           go test -tags postgres -race -count=1 -timeout=300s
@@ -135,7 +135,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
       - name: Conformance
         run: >-
           go test -tags redis -race -count=1 -timeout=300s
@@ -176,7 +176,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
       - name: Conformance (Redis driver against Valkey)
         run: >-
           go test -tags redis -race -count=1 -timeout=300s
@@ -213,7 +213,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
       - name: Conformance
         run: >-
           go test -tags memcached -race -count=1 -timeout=300s
@@ -266,7 +266,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
       - name: Cluster conformance
         run: >-
           go test -tags memcached_cluster -race -count=1 -timeout=300s
@@ -299,7 +299,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
       - name: Start cluster
         run: |
           docker compose -f test/conformance/redis/docker-compose.cluster.yml up -d
@@ -385,7 +385,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
       - name: Start sentinel stack
         run: |
           docker compose -f test/conformance/redis/docker-compose.sentinel.yml up -d

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
       - name: Request root module from proxy
         run: |
           VERSION="${{ github.event.release.tag_name }}"

--- a/engine/epoll/detach_inline_regression_linux_test.go
+++ b/engine/epoll/detach_inline_regression_linux_test.go
@@ -1,0 +1,209 @@
+//go:build linux
+
+package epoll_test
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/goceleris/celeris"
+	"github.com/goceleris/celeris/middleware/sse"
+	"github.com/goceleris/celeris/middleware/websocket"
+)
+
+// TestDetachInlineNoDoubleUnlock is the regression pin for celeris#309:
+// the per-handler-async inline dispatch path (celeris#300/#302) crashed the
+// process with "fatal error: sync: unlock of unlocked mutex" on the FIRST
+// WebSocket upgrade (/ws) or SSE request (/events) on the epoll engine.
+//
+// Trigger conditions, ALL required (this is why the pre-existing
+// middleware/{websocket,sse} engine tests missed it):
+//
+//   - The server registers at least one .Async() route. This flips
+//     Config.AsyncHandlers on for the WHOLE engine (server.go: hasAsyncRoutes
+//     → AsyncHandlers=true), so the epoll Loop runs with l.async==true even
+//     when Config.AsyncHandlers was left default-false (the "sync" engine
+//     label the benchmark uses).
+//   - The /ws and /events routes are themselves SYNC (detached flows run
+//     async by construction via their middleware goroutine, so they are not
+//     marked .Async()).
+//   - A fresh keep-alive conn's FIRST request is the /ws or /events one, so
+//     it runs INLINE on the event-loop thread (tryInline: l.async &&
+//     !cs.asyncPromoted). The inline path never Locks cs.detachMu before the
+//     handler runs, but the OnDetach guard used to Unlock it whenever
+//     l.async — unlocking a never-locked mutex → fatal.
+//
+// The pre-existing websocket_engine_linux_test / sse_engine_linux_test set
+// AsyncHandlers explicitly and register ONLY the streaming route (no .Async()
+// data route), so they never reach the inline-with-async-engine path; this
+// test reproduces the exact adapter shape (async data route + sync streaming
+// routes) the cluster benchmark crashed on.
+//
+// Asserts: across every engine the streaming upgrade succeeds AND the server
+// is still alive afterwards (a crash would kill the test binary outright; the
+// post-streaming request additionally proves the process kept serving).
+func TestDetachInlineNoDoubleUnlock(t *testing.T) {
+	engines := []struct {
+		name   string
+		engine celeris.EngineType
+	}{
+		{"epoll", celeris.Epoll},
+		{"iouring", celeris.IOUring},
+		{"std", celeris.Std},
+	}
+	for _, eng := range engines {
+		eng := eng
+		t.Run(eng.name, func(t *testing.T) {
+			ln, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			addr := ln.Addr().String()
+
+			// AsyncHandlers deliberately LEFT DEFAULT (false). The .Async()
+			// data route below is what flips the engine into async mode —
+			// exactly as the probatorium celeris adapter does with its
+			// /db,/cache,/mc,/session driver routes. This combination (async
+			// data route + sync streaming routes, AsyncHandlers unset) is what
+			// the older streaming engine tests never exercised.
+			srv := celeris.New(celeris.Config{Engine: eng.engine})
+
+			// Async data route → forces l.async=true engine-wide.
+			srv.GET("/db/user/:id", func(c *celeris.Context) error {
+				return c.String(200, "user")
+			}).Async()
+
+			// Sync streaming routes (NOT .Async()) — detached flows.
+			srv.GET("/ws", websocket.New(websocket.Config{
+				CheckOrigin: func(c *celeris.Context) bool { return true },
+				Handler: func(c *websocket.Conn) {
+					for {
+						mt, msg, rerr := c.ReadMessage()
+						if rerr != nil {
+							return
+						}
+						if werr := c.WriteMessage(mt, msg); werr != nil {
+							return
+						}
+					}
+				},
+			}))
+			srv.GET("/events", sse.New(sse.Config{
+				HeartbeatInterval: -1,
+				Handler: func(client *sse.Client) {
+					tick := time.NewTicker(50 * time.Millisecond)
+					defer tick.Stop()
+					ctx := client.Context()
+					for n := 0; n < 3; {
+						select {
+						case <-ctx.Done():
+							return
+						case <-tick.C:
+							n++
+							if err := client.Send(sse.Event{Event: "tick", Data: fmt.Sprintf("%d", n)}); err != nil {
+								return
+							}
+						}
+					}
+				},
+			}))
+
+			var startErr atomic.Pointer[error]
+			startCtx, startCancel := context.WithCancel(context.Background())
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				if e := srv.StartWithListenerAndContext(startCtx, ln); e != nil {
+					startErr.Store(&e)
+				}
+			}()
+			time.Sleep(500 * time.Millisecond)
+			if p := startErr.Load(); p != nil {
+				msg := (*p).Error()
+				if strings.Contains(msg, "io_uring") || strings.Contains(msg, "not available") {
+					t.Skipf("engine unavailable on this runner: %v", *p)
+				}
+				t.Fatalf("server start: %v", *p)
+			}
+			defer func() {
+				startCancel()
+				select {
+				case <-done:
+				case <-time.After(3 * time.Second):
+					t.Log("server goroutine did not exit within 3s")
+				}
+			}()
+
+			// --- WS upgrade on a FRESH conn (first request → inline path) ---
+			t.Run("ws", func(t *testing.T) {
+				conn, derr := net.DialTimeout("tcp", addr, time.Second)
+				if derr != nil {
+					t.Fatal(derr)
+				}
+				defer func() { _ = conn.Close() }()
+				_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+				req := "GET /ws HTTP/1.1\r\nHost: " + addr + "\r\n" +
+					"Connection: Upgrade\r\nUpgrade: websocket\r\n" +
+					"Sec-WebSocket-Version: 13\r\n" +
+					"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n"
+				if _, werr := conn.Write([]byte(req)); werr != nil {
+					t.Fatal(werr)
+				}
+				line, rerr := bufio.NewReader(conn).ReadString('\n')
+				if rerr != nil {
+					t.Fatalf("read 101 line: %v", rerr)
+				}
+				if !strings.HasPrefix(line, "HTTP/1.1 101") {
+					t.Fatalf("expected 101 Switching Protocols, got %q", strings.TrimSpace(line))
+				}
+			})
+
+			// --- SSE on a FRESH conn (first request → inline path) ---
+			t.Run("sse", func(t *testing.T) {
+				conn, derr := net.DialTimeout("tcp", addr, time.Second)
+				if derr != nil {
+					t.Fatal(derr)
+				}
+				defer func() { _ = conn.Close() }()
+				_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+				req := "GET /events HTTP/1.1\r\nHost: " + addr + "\r\nAccept: text/event-stream\r\n\r\n"
+				if _, werr := conn.Write([]byte(req)); werr != nil {
+					t.Fatal(werr)
+				}
+				line, rerr := bufio.NewReader(conn).ReadString('\n')
+				if rerr != nil {
+					t.Fatalf("read status line: %v", rerr)
+				}
+				if !strings.HasPrefix(line, "HTTP/1.1 200") {
+					t.Fatalf("expected 200 for SSE, got %q", strings.TrimSpace(line))
+				}
+			})
+
+			// --- liveness: the server still serves after streaming ---
+			t.Run("alive", func(t *testing.T) {
+				conn, derr := net.DialTimeout("tcp", addr, time.Second)
+				if derr != nil {
+					t.Fatalf("server unreachable after streaming (crashed?): %v", derr)
+				}
+				defer func() { _ = conn.Close() }()
+				_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+				if _, werr := conn.Write([]byte("GET /db/user/42 HTTP/1.1\r\nHost: " + addr + "\r\n\r\n")); werr != nil {
+					t.Fatal(werr)
+				}
+				line, rerr := bufio.NewReader(conn).ReadString('\n')
+				if rerr != nil {
+					t.Fatalf("server not serving after streaming (crashed?): %v", rerr)
+				}
+				if !strings.HasPrefix(line, "HTTP/1.1 200") {
+					t.Fatalf("expected 200 from async route post-streaming, got %q", strings.TrimSpace(line))
+				}
+			})
+		})
+	}
+}

--- a/engine/epoll/loop.go
+++ b/engine/epoll/loop.go
@@ -1123,7 +1123,28 @@ func (l *Loop) initProtocol(cs *connState) {
 			// and have the dispatch goroutine observe
 			// asyncDetachUnlocked to skip its symmetric Unlock when
 			// ProcessH1 returns. See celeris#273.
-			if l.async && cs.detachMu != nil && !cs.asyncDetachUnlocked {
+			//
+			// Gate on cs.asyncPromoted: detachMu is Locked around
+			// ProcessH1 ONLY by runAsyncHandler (the dispatch goroutine),
+			// which runs exclusively for PROMOTED conns. With per-handler
+			// async (celeris#300/#302) an async-mode conn (l.async==true,
+			// forced on whenever any route opts into .Async()) runs its
+			// FIRST request INLINE on the event-loop thread when the conn
+			// is not yet promoted (tryInline at drainRead). A SYNC route
+			// — e.g. the WebSocket /ws upgrade or the SSE /events stream,
+			// which are not themselves .Async() — does not bail with
+			// ErrAsyncDispatch, so its handler runs inline and calls
+			// Context.Detach() → OnDetach while detachMu was NEVER Locked
+			// (the inline path locks it only at the post-handler flush,
+			// loop.go:896). Unlocking here under the old `l.async`-only
+			// guard then faulted with "sync: unlock of unlocked mutex",
+			// fatally crashing the process on the first /ws or /events
+			// request. The asyncPromoted gate restricts the Unlock to the
+			// dispatch-goroutine path that actually holds the lock; the
+			// inline flush owns its own Lock/Unlock around flushWrites, so
+			// the guarded writeFn (which re-locks) still serialises with
+			// the event loop. See celeris#309.
+			if l.async && cs.asyncPromoted && cs.detachMu != nil && !cs.asyncDetachUnlocked {
 				cs.asyncDetachUnlocked = true
 				cs.detachMu.Unlock()
 			}

--- a/engine/iouring/drain_recv_test.go
+++ b/engine/iouring/drain_recv_test.go
@@ -1,0 +1,83 @@
+//go:build linux
+
+package iouring
+
+import (
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestDrainRecvBufferNonBlocking is the regression guard for celeris#311.
+//
+// drainRecvBuffer runs on the io_uring event-loop worker thread during the
+// graceful detached-close path (SHUT_WR → drain → close). The sockets are in
+// blocking mode, so the prior unix.Read implementation would block forever when
+// a connection was closed before the peer's FIN arrived (the churn-close race),
+// wedging the worker — and with enough concurrent detached-closes the whole
+// engine stopped servicing requests.
+//
+// This test puts a blocking-mode socket in exactly that state (empty receive
+// buffer, peer still open so no FIN) and asserts drainRecvBuffer returns
+// promptly instead of blocking. With the old blocking Read it hangs and trips
+// the timeout; with the MSG_DONTWAIT drain it returns immediately.
+func TestDrainRecvBufferNonBlocking(t *testing.T) {
+	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+	if err != nil {
+		t.Fatalf("socketpair: %v", err)
+	}
+	defer func() { _ = unix.Close(fds[0]) }()
+	defer func() { _ = unix.Close(fds[1]) }()
+
+	// fds[0] is blocking (socketpair default) with an empty recv buffer and the
+	// peer (fds[1]) still open — the exact state that hung the old Read.
+	done := make(chan struct{})
+	go func() {
+		drainRecvBuffer(fds[0])
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("drainRecvBuffer blocked on an empty blocking socket (celeris#311 regression)")
+	}
+}
+
+// TestDrainRecvBufferDrainsThenReturns verifies the drain still does its job:
+// it consumes data already queued in the receive buffer (so close() does not
+// RST away a staged GOAWAY / close frame) and then returns once the buffer is
+// empty — without blocking on the still-open peer.
+func TestDrainRecvBufferDrainsThenReturns(t *testing.T) {
+	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+	if err != nil {
+		t.Fatalf("socketpair: %v", err)
+	}
+	defer func() { _ = unix.Close(fds[0]) }()
+	defer func() { _ = unix.Close(fds[1]) }()
+
+	if _, err := unix.Write(fds[1], []byte("queued bytes the drain must discard")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		drainRecvBuffer(fds[0])
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("drainRecvBuffer blocked after draining queued data (celeris#311 regression)")
+	}
+
+	// Buffer must now be empty: a non-blocking read returns EAGAIN/EWOULDBLOCK.
+	var buf [64]byte
+	n, _, rerr := unix.Recvfrom(fds[0], buf[:], unix.MSG_DONTWAIT)
+	if n > 0 {
+		t.Fatalf("drainRecvBuffer left %d bytes undrained", n)
+	}
+	if rerr != unix.EAGAIN && rerr != unix.EWOULDBLOCK {
+		t.Fatalf("expected EAGAIN after drain, got n=%d err=%v", n, rerr)
+	}
+}

--- a/engine/iouring/worker.go
+++ b/engine/iouring/worker.go
@@ -1140,7 +1140,22 @@ func (w *Worker) initProtocol(cs *connState) {
 			// celeris#273 — pre-fix, /ws and /events would TIMEOUT on
 			// iouring + AsyncHandlers because the dispatch goroutine
 			// was deadlocked on its own re-entrant Lock attempt.
-			if w.async && cs.detachMu != nil && !cs.asyncDetachUnlocked {
+			//
+			// Gate on cs.asyncPromoted: detachMu is Locked around
+			// ProcessH1 ONLY by runAsyncHandler (the dispatch goroutine),
+			// which runs exclusively for PROMOTED conns. With per-handler
+			// async (#300/#302) a not-yet-promoted async-mode conn runs
+			// its FIRST request INLINE on the worker thread (tryInline);
+			// a SYNC route — the WebSocket /ws upgrade or SSE /events
+			// stream, which are not themselves .Async() — does not bail
+			// with ErrAsyncDispatch, so its handler runs inline and calls
+			// Context.Detach() → OnDetach while detachMu was NEVER Locked.
+			// Unlocking here under the old w.async-only guard then faulted
+			// with "sync: unlock of unlocked mutex", fatally crashing the
+			// process on the first /ws or /events request. The
+			// asyncPromoted gate restricts the Unlock to the dispatch-
+			// goroutine path that actually holds the lock. See celeris#309.
+			if w.async && cs.asyncPromoted && cs.detachMu != nil && !cs.asyncDetachUnlocked {
 				cs.asyncDetachUnlocked = true
 				cs.detachMu.Unlock()
 			}

--- a/engine/iouring/worker.go
+++ b/engine/iouring/worker.go
@@ -2990,13 +2990,27 @@ func (w *Worker) shutdown() {
 	w.asyncWG.Wait()
 }
 
-// drainRecvBuffer reads and discards any data in the socket receive buffer.
-// This prevents close() from sending RST (which discards unsent data like GOAWAY).
+// drainRecvMaxReads bounds drainRecvBuffer so a peer that keeps trickling bytes
+// on a half-closed connection cannot pin the worker. 64 × 512 B = 32 KiB is far
+// more than any legitimate post-shutdown tail (a queued GOAWAY / WS close echo).
+const drainRecvMaxReads = 64
+
+// drainRecvBuffer non-blockingly reads and discards whatever is already in the
+// socket receive buffer, so the following close() will not send an RST that
+// discards unsent data still staged in the send buffer (a queued GOAWAY / WS
+// close frame).
+//
+// It MUST NOT block. It runs on the io_uring event-loop worker thread and the
+// socket is in blocking mode, so a plain unix.Read here waits for data or FIN
+// that may never arrive on a churn-closed / half-closed detached connection —
+// wedging the worker, and with enough concurrent detached-closes the whole
+// engine (it accepts connections and then services nothing). See celeris#311.
+// MSG_DONTWAIT makes each read return EAGAIN the moment the buffer is empty.
 func drainRecvBuffer(fd int) {
 	var buf [512]byte
-	for {
-		n, _ := unix.Read(fd, buf[:])
-		if n <= 0 {
+	for i := 0; i < drainRecvMaxReads; i++ {
+		n, _, err := unix.Recvfrom(fd, buf[:], unix.MSG_DONTWAIT)
+		if n <= 0 || err != nil {
 			return
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/goceleris/celeris
 
-go 1.26.3
+go 1.26.4
 
 require (
 	golang.org/x/net v0.55.0

--- a/internal/conn/h2_test.go
+++ b/internal/conn/h2_test.go
@@ -466,6 +466,60 @@ func TestProcessH2_ServerRSTFreesSlot(t *testing.T) {
 	}
 }
 
+// TestProcessH2_NoWriteHandlerFreesSlot is a regression test for a
+// MAX_CONCURRENT_STREAMS slot leak on the inline early-return path. An
+// inline-eligible request (GET/HEAD with END_STREAM, so the stream is
+// HalfClosedRemote = active/counted) whose handler returns WITHOUT writing a
+// response takes the `!headersSent` branch (the adapter emits an empty 200) and
+// returns BEFORE the state transition — so the teardown defer removed the
+// still-active stream via RemoveStreamFromMap, which never decrements
+// activeStreams, leaking one slot per request until the limit pinned (map
+// empty, every new HEADERS REFUSED). Trigger in prod: any inline GET/HEAD route
+// that returns without writing (early return, 204-style, recovered panic). The
+// fix transitions the stream to Closed in the defer so the slot frees on every
+// exit path. Pre-fix: activeStreams pins at 1 after the first stream.
+func TestProcessH2_NoWriteHandlerFreesSlot(t *testing.T) {
+	const (
+		maxStreams = 8
+		nStreams   = 40 // >> maxStreams: a leaked slot pins the limit fast
+	)
+	h := silentHandler{}
+	write := func([]byte) {}
+	cfg := H2Config{MaxConcurrentStreams: maxStreams}
+	state := NewH2State(h, cfg, write, -1)
+	mgr := state.processor.GetManager()
+
+	var preface bytes.Buffer
+	preface.WriteString(frame.ClientPreface)
+	pf := http2.NewFramer(&preface, nil)
+	if err := pf.WriteSettings(); err != nil {
+		t.Fatalf("WriteSettings: %v", err)
+	}
+	if err := ProcessH2(context.Background(), preface.Bytes(), state, h, write, cfg); err != nil {
+		t.Fatalf("ProcessH2 preface: %v", err)
+	}
+
+	hdr := encodeH2Headers(t, [][2]string{
+		{":method", "GET"}, {":scheme", "http"}, {":path", "/"}, {":authority", "x"},
+	})
+	for i := 0; i < nStreams; i++ {
+		sid := uint32(2*i + 1)
+		var b bytes.Buffer
+		fr := http2.NewFramer(&b, nil)
+		if err := fr.WriteRawFrame(http2.FrameHeaders,
+			http2.FlagHeadersEndStream|http2.FlagHeadersEndHeaders, sid, hdr); err != nil {
+			t.Fatalf("WriteHeaders sid=%d: %v", sid, err)
+		}
+		if err := ProcessH2(context.Background(), b.Bytes(), state, h, write, cfg); err != nil {
+			t.Fatalf("ProcessH2 sid=%d: %v", sid, err)
+		}
+		if got := mgr.CountActiveStreams(); got != 0 {
+			t.Fatalf("after no-write stream %d: activeStreams=%d, want 0 (slot leaked — streamCount=%d)",
+				sid, got, mgr.StreamCount())
+		}
+	}
+}
+
 // countGoAwayFlowControl parses captured server output and returns how many
 // GOAWAY frames carry FLOW_CONTROL_ERROR — the symptom of the connection-window
 // overflow bug.

--- a/internal/conn/h2_test.go
+++ b/internal/conn/h2_test.go
@@ -280,3 +280,188 @@ func TestProcessH2_PipelinedCompletedStreamsNotRefused(t *testing.T) {
 		t.Fatalf("server answered %d/%d pipelined requests", served, nStreams)
 	}
 }
+
+// TestProcessH2_StalledStreamsReleaseSlot is a regression test for the
+// MAX_CONCURRENT_STREAMS slot LEAK under sustained large responses that
+// backpressure on flow control (probatorium grid get-json-64k-h2:
+// ~410M stream errors / sustained REFUSED storm).
+//
+// With a small per-stream INITIAL_WINDOW_SIZE, every response STALLS: the
+// handler buffers the un-sendable tail of the body and the inline path keeps
+// the stream alive (state half-closed-remote, counting toward activeStreams)
+// until a WINDOW_UPDATE opens the window. If the WINDOW_UPDATE flush path
+// fails to transition the now-fully-sent stream to closed AND decrement the
+// active count exactly once, the slot LEAKS. Over many sequential
+// stalled-then-released streams the leak accumulates until activeStreams
+// pins at the limit and every new HEADERS is RST'd with REFUSED_STREAM.
+//
+// Each stream here is delivered + released in its OWN ProcessH2 call (one
+// recv buffer per stream), mirroring the live load where streams arrive
+// over wall-time rather than all in one batch.
+func TestProcessH2_StalledStreamsReleaseSlot(t *testing.T) {
+	const (
+		maxStreams = 8
+		nStreams   = 256 // >> maxStreams: a leaking slot pins the limit fast
+		window     = 16  // tiny window: body tail always stalls on flow control
+	)
+	// Body larger than the window so the response always buffers a tail and
+	// stalls — the precondition for the leak.
+	h := respondHandler{body: bytes.Repeat([]byte("x"), 64)}
+	var mu sync.Mutex
+	var writes []byte
+	write := func(b []byte) {
+		mu.Lock()
+		writes = append(writes, b...)
+		mu.Unlock()
+	}
+	cfg := H2Config{MaxConcurrentStreams: maxStreams}
+	state := NewH2State(h, cfg, write, -1)
+
+	hdr := encodeH2Headers(t, [][2]string{
+		{":method", "GET"}, {":scheme", "http"}, {":path", "/"}, {":authority", "x"},
+	})
+
+	mgr := state.processor.GetManager()
+
+	// Preface + client SETTINGS in the first buffer. The client advertises a
+	// tiny SETTINGS_INITIAL_WINDOW_SIZE so OUR per-stream SEND window starts
+	// small — every response then stalls on flow control, exactly as a 64 KB
+	// body does against the RFC-default 65535 window on the live grid.
+	var preface bytes.Buffer
+	preface.WriteString(frame.ClientPreface)
+	pf := http2.NewFramer(&preface, nil)
+	if err := pf.WriteSettings(http2.Setting{
+		ID: http2.SettingInitialWindowSize, Val: window,
+	}); err != nil {
+		t.Fatalf("WriteSettings: %v", err)
+	}
+	if err := ProcessH2(context.Background(), preface.Bytes(), state, h, write, cfg); err != nil {
+		t.Fatalf("ProcessH2 preface: %v", err)
+	}
+
+	for i := 0; i < nStreams; i++ {
+		sid := uint32(2*i + 1)
+
+		// 1) HEADERS (complete GET). Response stalls: body tail buffered,
+		//    stream stays active pending WINDOW_UPDATE.
+		var hb bytes.Buffer
+		hf := http2.NewFramer(&hb, nil)
+		if err := hf.WriteRawFrame(http2.FrameHeaders,
+			http2.FlagHeadersEndStream|http2.FlagHeadersEndHeaders, sid, hdr); err != nil {
+			t.Fatalf("WriteHeaders sid=%d: %v", sid, err)
+		}
+		if err := ProcessH2(context.Background(), hb.Bytes(), state, h, write, cfg); err != nil {
+			t.Fatalf("ProcessH2 headers sid=%d: %v", sid, err)
+		}
+
+		// 2) WINDOW_UPDATEs to open the window fully so the buffered tail
+		//    flushes with END_STREAM and the stream completes. Send enough
+		//    increments to cover the whole body.
+		var wb bytes.Buffer
+		wf := http2.NewFramer(&wb, nil)
+		for sent := window; sent < len(h.body); sent += window {
+			if err := wf.WriteWindowUpdate(sid, uint32(window)); err != nil {
+				t.Fatalf("WriteWindowUpdate sid=%d: %v", sid, err)
+			}
+		}
+		if err := ProcessH2(context.Background(), wb.Bytes(), state, h, write, cfg); err != nil {
+			t.Fatalf("ProcessH2 window-update sid=%d: %v", sid, err)
+		}
+
+		// After each stream is fully released, activeStreams must return to 0.
+		// If the slot leaks, this climbs to maxStreams and never recovers.
+		if got := mgr.CountActiveStreams(); got != 0 {
+			t.Fatalf("after stream %d completed: activeStreams=%d, want 0 (slot leaked)", sid, got)
+		}
+	}
+
+	// Belt-and-suspenders: no stream may ever have been REFUSED.
+	mu.Lock()
+	out := append([]byte(nil), writes...)
+	mu.Unlock()
+	refused := 0
+	rf := http2.NewFramer(nil, bytes.NewReader(out))
+	rf.SetMaxReadFrameSize(1 << 20)
+	for {
+		f, err := rf.ReadFrame()
+		if err != nil {
+			break
+		}
+		if v, ok := f.(*http2.RSTStreamFrame); ok && v.ErrCode == http2.ErrCodeRefusedStream {
+			refused++
+		}
+	}
+	if refused != 0 {
+		t.Fatalf("got %d RST_STREAM(REFUSED_STREAM), want 0 — stalled streams must free their slot after flush", refused)
+	}
+}
+
+// silentHandler never writes a response, leaving the stream active so a
+// server-initiated RST fires while the stream still counts toward the limit.
+type silentHandler struct{}
+
+func (silentHandler) HandleStream(_ context.Context, _ *stream.Stream) error { return nil }
+
+// TestProcessH2_ServerRSTFreesSlot is a regression test for the
+// MAX_CONCURRENT_STREAMS slot LEAK that produced the sustained
+// REFUSED_STREAM storm on the get-json-64k-h2 grid cell (~410M errors over
+// 40 s, throughput degrading as activeStreams pinned at the limit).
+//
+// A server-initiated RST_STREAM on a still-active stream (here: request body
+// exceeds MaxRequestBodySize) removed the stream from the manager map but
+// never decremented activeStreams — the stream vanished yet its concurrency
+// slot was leaked forever. Under sustained load a steady trickle of streams
+// hit a transient RST condition, leaking one slot each, until activeStreams
+// saturated at MaxConcurrentStreams and every new HEADERS was refused. The
+// fix decrements the active count for any active stream removed via
+// DeleteStream, regardless of which close path reached it.
+//
+// The smoking gun: after each RST the stream is GONE from the map
+// (StreamCount → 0) but activeStreams stays pinned — map empty, limit full.
+func TestProcessH2_ServerRSTFreesSlot(t *testing.T) {
+	const (
+		maxStreams = 8
+		nStreams   = 40 // >> maxStreams: a leaked slot pins the limit fast
+	)
+	h := silentHandler{}
+	write := func([]byte) {}
+	cfg := H2Config{MaxConcurrentStreams: maxStreams, MaxRequestBodySize: 4}
+	state := NewH2State(h, cfg, write, -1)
+	mgr := state.processor.GetManager()
+
+	var preface bytes.Buffer
+	preface.WriteString(frame.ClientPreface)
+	pf := http2.NewFramer(&preface, nil)
+	if err := pf.WriteSettings(); err != nil {
+		t.Fatalf("WriteSettings: %v", err)
+	}
+	if err := ProcessH2(context.Background(), preface.Bytes(), state, h, write, cfg); err != nil {
+		t.Fatalf("ProcessH2 preface: %v", err)
+	}
+
+	hdr := encodeH2Headers(t, [][2]string{
+		{":method", "POST"}, {":scheme", "http"}, {":path", "/"}, {":authority", "x"},
+	})
+	for i := 0; i < nStreams; i++ {
+		sid := uint32(2*i + 1)
+		// Open the stream (HEADERS, no END_STREAM → active), then send a DATA
+		// frame whose body exceeds MaxRequestBodySize → server RST_STREAM via
+		// sendRSTStreamAndMarkClosed on an active, in-map stream.
+		var b bytes.Buffer
+		fr := http2.NewFramer(&b, nil)
+		if err := fr.WriteRawFrame(http2.FrameHeaders, http2.FlagHeadersEndHeaders, sid, hdr); err != nil {
+			t.Fatalf("WriteHeaders sid=%d: %v", sid, err)
+		}
+		if err := fr.WriteData(sid, false, []byte("body-too-large")); err != nil {
+			t.Fatalf("WriteData sid=%d: %v", sid, err)
+		}
+		// A frame-level error may surface as a ProcessH2 error on the body-cap
+		// path; that is fine — we only care that the slot is reclaimed.
+		_ = ProcessH2(context.Background(), b.Bytes(), state, h, write, cfg)
+
+		if got := mgr.CountActiveStreams(); got != 0 {
+			t.Fatalf("after RST of stream %d: activeStreams=%d, want 0 (slot leaked — streamCount=%d)",
+				sid, got, mgr.StreamCount())
+		}
+	}
+}

--- a/internal/conn/h2_test.go
+++ b/internal/conn/h2_test.go
@@ -465,3 +465,272 @@ func TestProcessH2_ServerRSTFreesSlot(t *testing.T) {
 		}
 	}
 }
+
+// countGoAwayFlowControl parses captured server output and returns how many
+// GOAWAY frames carry FLOW_CONTROL_ERROR — the symptom of the connection-window
+// overflow bug.
+func countGoAwayFlowControl(t *testing.T, out []byte) int {
+	t.Helper()
+	rf := http2.NewFramer(nil, bytes.NewReader(out))
+	rf.SetMaxReadFrameSize(1 << 20)
+	n := 0
+	for {
+		f, err := rf.ReadFrame()
+		if err != nil {
+			break
+		}
+		if ga, ok := f.(*http2.GoAwayFrame); ok && ga.ErrCode == http2.ErrCodeFlowControl {
+			n++
+		}
+	}
+	return n
+}
+
+// TestProcessH2_ConnectionWindowNotOverflowed is the regression test for the
+// 64 KB H2 "error storm" (probatorium grid get-json-64k-h2: ~300–560M loadgen
+// errors). celeris never enforced/debited the CONNECTION-level SEND flow-control
+// window (RFC 7540 §6.9): the send path debited only the per-stream window. A
+// well-behaved client replenishes the connection window with WINDOW_UPDATE(0)
+// credit equal to the DATA it has consumed; because the server never spent the
+// connection window, that credit accumulated on top of a never-shrinking window
+// and climbed 65535 → 2^31-1 → overflow, at which point celeris aborted the
+// WHOLE connection with GOAWAY(FLOW_CONTROL_ERROR, lastStreamID=0), killing
+// every in-flight stream. (Go net/http2 — chi/echo — debits the connection
+// send window, so it stays bounded and never overflows.)
+//
+// The client here advertises a huge per-stream INITIAL_WINDOW_SIZE so the
+// per-stream window is never the bottleneck — every large response is gated by
+// the 65535-byte CONNECTION window exactly as a 64 KB body is on the live grid —
+// and replenishes the connection window with credit EQUAL to the bytes it
+// consumed (faithful client behaviour). With the fix the window is debited by
+// every send, so credit only refills what was spent and the window stays pinned
+// near its initial value; pre-fix it never shrinks, so the matching credit piles
+// up unbounded (and the connection-stalled tail never even re-flushes, so bodies
+// hang). Assertions: no FLOW_CONTROL GOAWAY, the window stays bounded, every
+// body is delivered in full, and no concurrency slot leaks.
+func TestProcessH2_ConnectionWindowNotOverflowed(t *testing.T) {
+	const (
+		nStreams  = 512      // pre-fix the window climbs by ~bodyLen each → ≫ bound
+		bodyLen   = 64 << 10 // 64 KB responses (the live get-json-64k-h2 shape)
+		streamWin = 1 << 30  // 1 GiB per-stream window: never the bottleneck
+		initConn  = 65535    // RFC-default connection window celeris starts with
+		creditPer = 64 << 10 // client credits exactly the body it consumed
+	)
+	h := respondHandler{body: bytes.Repeat([]byte("x"), bodyLen)}
+	var mu sync.Mutex
+	var writes []byte
+	write := func(b []byte) {
+		mu.Lock()
+		writes = append(writes, b...)
+		mu.Unlock()
+	}
+	cfg := H2Config{MaxConcurrentStreams: 100}
+	state := NewH2State(h, cfg, write, -1)
+	mgr := state.processor.GetManager()
+
+	// Preface + client SETTINGS advertising a huge per-stream initial window.
+	var preface bytes.Buffer
+	preface.WriteString(frame.ClientPreface)
+	pf := http2.NewFramer(&preface, nil)
+	if err := pf.WriteSettings(http2.Setting{
+		ID: http2.SettingInitialWindowSize, Val: streamWin,
+	}); err != nil {
+		t.Fatalf("WriteSettings: %v", err)
+	}
+	if err := ProcessH2(context.Background(), preface.Bytes(), state, h, write, cfg); err != nil {
+		t.Fatalf("ProcessH2 preface: %v", err)
+	}
+
+	hdr := encodeH2Headers(t, [][2]string{
+		{":method", "GET"}, {":scheme", "http"}, {":path", "/"}, {":authority", "x"},
+	})
+
+	var totalData int
+	for i := 0; i < nStreams; i++ {
+		sid := uint32(2*i + 1)
+
+		// HEADERS (complete GET). The response (64 KB) sends up to the current
+		// connection window then stalls on it; the per-stream window has room.
+		var hb bytes.Buffer
+		hf := http2.NewFramer(&hb, nil)
+		if err := hf.WriteRawFrame(http2.FrameHeaders,
+			http2.FlagHeadersEndStream|http2.FlagHeadersEndHeaders, sid, hdr); err != nil {
+			t.Fatalf("WriteHeaders sid=%d: %v", sid, err)
+		}
+		if err := ProcessH2(context.Background(), hb.Bytes(), state, h, write, cfg); err != nil {
+			t.Fatalf("ProcessH2 headers sid=%d: %v", sid, err)
+		}
+
+		// Replenish the connection window with exactly what the body consumed,
+		// as a real client does once it reads the 64 KB response off the wire.
+		var wb bytes.Buffer
+		wf := http2.NewFramer(&wb, nil)
+		if err := wf.WriteWindowUpdate(0, creditPer); err != nil {
+			t.Fatalf("WriteWindowUpdate(0) i=%d: %v", i, err)
+		}
+		if err := ProcessH2(context.Background(), wb.Bytes(), state, h, write, cfg); err != nil {
+			t.Fatalf("ProcessH2 conn window-update i=%d: %v", i, err)
+		}
+	}
+
+	mu.Lock()
+	out := append([]byte(nil), writes...)
+	mu.Unlock()
+
+	// (a) No GOAWAY(FLOW_CONTROL) may ever be emitted.
+	if n := countGoAwayFlowControl(t, out); n != 0 {
+		t.Fatalf("got %d GOAWAY(FLOW_CONTROL_ERROR), want 0 — connection send window overflowed", n)
+	}
+
+	// (b) The connection window must stay bounded, NOT monotonically climb with
+	//     each stream. With the fix every send debits it so the matching credit
+	//     only refills the spend and it hovers near its initial value. Pre-fix
+	//     it never shrinks, so nStreams × creditPer (~32 MB here) piles on top.
+	if got := mgr.GetConnectionWindow(); got > initConn+creditPer {
+		t.Fatalf("connection window climbed to %d (bound %d) — sends are not debiting it",
+			got, initConn+creditPer)
+	}
+
+	// (c) Every body must be delivered in full. Pre-fix the connection-stalled
+	//     tail of each response never re-flushes (the WINDOW_UPDATE(0) handler
+	//     did not resume connection-stalled streams), so bytes go missing.
+	rf := http2.NewFramer(nil, bytes.NewReader(out))
+	rf.SetMaxReadFrameSize(1 << 20)
+	for {
+		f, err := rf.ReadFrame()
+		if err != nil {
+			break
+		}
+		if df, ok := f.(*http2.DataFrame); ok {
+			totalData += len(df.Data())
+		}
+	}
+	if want := nStreams * bodyLen; totalData != want {
+		t.Fatalf("delivered %d DATA bytes across all streams, want %d (connection-stalled tails dropped)",
+			totalData, want)
+	}
+
+	// (d) No concurrency slot may leak — every stream completed and released.
+	if got := mgr.CountActiveStreams(); got != 0 {
+		t.Fatalf("activeStreams=%d after all streams completed, want 0 (stalled streams leaked their slot)", got)
+	}
+}
+
+// streamDataBytes parses captured output and returns total DATA payload bytes
+// for streamID and whether a DATA frame carried END_STREAM.
+func streamDataBytes(t *testing.T, out []byte, streamID uint32) (total int, sawEnd bool) {
+	t.Helper()
+	rf := http2.NewFramer(nil, bytes.NewReader(out))
+	rf.SetMaxReadFrameSize(1 << 20)
+	for {
+		f, err := rf.ReadFrame()
+		if err != nil {
+			break
+		}
+		if df, ok := f.(*http2.DataFrame); ok && df.StreamID == streamID {
+			total += len(df.Data())
+			if df.StreamEnded() {
+				sawEnd = true
+			}
+		}
+	}
+	return total, sawEnd
+}
+
+// TestProcessH2_ConnWindowStallResumes proves two things:
+//
+//  1. The server MUST NOT send more body bytes than the CONNECTION window has
+//     authorized (RFC 7540 §6.9). Pre-fix the send path only consulted the
+//     per-stream window, so with a huge per-stream window it shipped the entire
+//     100 KB body even though the connection window only authorized 65535 bytes
+//     — a flow-control violation that on a real client triggers the overflow
+//     storm this PR fixes.
+//  2. A stream that stalls on the connection window RESUMES and delivers its
+//     full body once WINDOW_UPDATE(stream 0) credit arrives — the connection
+//     window re-flush. Without it the stalled tail would hang forever (the
+//     per-stream WINDOW_UPDATE path never fires; the peer only sends connection
+//     credit).
+func TestProcessH2_ConnWindowStallResumes(t *testing.T) {
+	const (
+		bodyLen   = 100 << 10 // 100 KB > the 65535-byte initial connection window
+		streamWin = 1 << 30   // per-stream window never blocks
+		initConn  = 65535     // RFC-default connection window celeris starts with
+	)
+	body := bytes.Repeat([]byte("y"), bodyLen)
+	h := respondHandler{body: body}
+	var mu sync.Mutex
+	var writes []byte
+	write := func(b []byte) {
+		mu.Lock()
+		writes = append(writes, b...)
+		mu.Unlock()
+	}
+	cfg := H2Config{MaxConcurrentStreams: 100}
+	state := NewH2State(h, cfg, write, -1)
+
+	var preface bytes.Buffer
+	preface.WriteString(frame.ClientPreface)
+	pf := http2.NewFramer(&preface, nil)
+	if err := pf.WriteSettings(http2.Setting{
+		ID: http2.SettingInitialWindowSize, Val: streamWin,
+	}); err != nil {
+		t.Fatalf("WriteSettings: %v", err)
+	}
+	if err := ProcessH2(context.Background(), preface.Bytes(), state, h, write, cfg); err != nil {
+		t.Fatalf("ProcessH2 preface: %v", err)
+	}
+
+	hdr := encodeH2Headers(t, [][2]string{
+		{":method", "GET"}, {":scheme", "http"}, {":path", "/"}, {":authority", "x"},
+	})
+	sid := uint32(1)
+	var hb bytes.Buffer
+	hf := http2.NewFramer(&hb, nil)
+	if err := hf.WriteRawFrame(http2.FrameHeaders,
+		http2.FlagHeadersEndStream|http2.FlagHeadersEndHeaders, sid, hdr); err != nil {
+		t.Fatalf("WriteHeaders: %v", err)
+	}
+	if err := ProcessH2(context.Background(), hb.Bytes(), state, h, write, cfg); err != nil {
+		t.Fatalf("ProcessH2 headers: %v", err)
+	}
+
+	// Before ANY connection credit: at most the initial connection window may
+	// have been sent. Pre-fix the server ships the whole 100 KB body here
+	// (per-stream window had room), exceeding what the connection authorized.
+	mu.Lock()
+	afterHeaders := append([]byte(nil), writes...)
+	mu.Unlock()
+	if sent, _ := streamDataBytes(t, afterHeaders, sid); sent > initConn {
+		t.Fatalf("server sent %d body bytes with only %d connection window authorized — connection flow control not enforced",
+			sent, initConn)
+	}
+
+	// Drip connection credit in chunks until the whole body is delivered. The
+	// stalled tail must resume off the WINDOW_UPDATE(0) re-flush.
+	for i := 0; i < 8; i++ {
+		var wb bytes.Buffer
+		wf := http2.NewFramer(&wb, nil)
+		if err := wf.WriteWindowUpdate(0, 32<<10); err != nil {
+			t.Fatalf("WriteWindowUpdate(0): %v", err)
+		}
+		if err := ProcessH2(context.Background(), wb.Bytes(), state, h, write, cfg); err != nil {
+			t.Fatalf("ProcessH2 conn window-update %d: %v", i, err)
+		}
+	}
+
+	mu.Lock()
+	out := append([]byte(nil), writes...)
+	mu.Unlock()
+
+	if n := countGoAwayFlowControl(t, out); n != 0 {
+		t.Fatalf("got %d GOAWAY(FLOW_CONTROL_ERROR), want 0", n)
+	}
+
+	dataBytes, sawEndStream := streamDataBytes(t, out, sid)
+	if dataBytes != bodyLen {
+		t.Fatalf("delivered %d body bytes, want %d (stream stalled on connection window never resumed fully)", dataBytes, bodyLen)
+	}
+	if !sawEndStream {
+		t.Fatal("no END_STREAM DATA frame — response did not complete")
+	}
+}

--- a/internal/conn/h2_test.go
+++ b/internal/conn/h2_test.go
@@ -6,6 +6,9 @@ import (
 	"sync"
 	"testing"
 
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
+
 	"github.com/goceleris/celeris/protocol/h2/frame"
 	"github.com/goceleris/celeris/protocol/h2/stream"
 )
@@ -171,5 +174,109 @@ func TestInjectStreamHeaders_WithBody(t *testing.T) {
 	}
 	if h.method != "POST" || h.path != "/submit" || h.body != "hello world" {
 		t.Fatalf("method=%q path=%q body=%q", h.method, h.path, h.body)
+	}
+}
+
+// respondHandler answers every stream with a fixed 200 response so the inline
+// handler path runs to completion (END_STREAM sent) and reaches the stream-slot
+// reclamation logic under test.
+type respondHandler struct{ body []byte }
+
+func (h respondHandler) HandleStream(_ context.Context, s *stream.Stream) error {
+	if s.ResponseWriter == nil {
+		return nil
+	}
+	return s.ResponseWriter.WriteResponse(s, 200, [][2]string{{"content-type", "text/plain"}}, h.body)
+}
+
+func encodeH2Headers(t *testing.T, headers [][2]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	enc := hpack.NewEncoder(&buf)
+	for _, h := range headers {
+		if err := enc.WriteField(hpack.HeaderField{Name: h[0], Value: h[1]}); err != nil {
+			t.Fatalf("hpack encode: %v", err)
+		}
+	}
+	return buf.Bytes()
+}
+
+// TestProcessH2_PipelinedCompletedStreamsNotRefused is a regression test for the
+// REFUSED_STREAM storm (probatorium grid get-json-64k-h2: ~50M stream errors).
+// When a single recv buffer carries more pipelined, already-complete GET
+// requests than SETTINGS_MAX_CONCURRENT_STREAMS, the server must NOT refuse the
+// excess: inline handlers run sequentially, so each stream completes
+// (END_STREAM) before the next opens — at most one stream is ever genuinely
+// open. A completed stream must free its concurrency slot immediately even
+// though its map removal is deferred to FlushInlineCleanup (hasMoreFrames=true
+// for the whole batch). Before the fix, streams past the limit got
+// RST_STREAM(REFUSED_STREAM); after, all are served.
+func TestProcessH2_PipelinedCompletedStreamsNotRefused(t *testing.T) {
+	const (
+		maxStreams = 8
+		nStreams   = 20 // > maxStreams: pre-fix refused streams 9..20
+	)
+	h := respondHandler{body: []byte("ok")}
+	var mu sync.Mutex
+	var writes []byte
+	write := func(b []byte) {
+		mu.Lock()
+		writes = append(writes, b...)
+		mu.Unlock()
+	}
+	cfg := H2Config{MaxConcurrentStreams: maxStreams}
+	state := NewH2State(h, cfg, write, -1)
+
+	// One buffer: client preface + empty client SETTINGS + nStreams complete
+	// GET HEADERS frames (odd stream IDs). Delivering them in a single
+	// ProcessH2 call sets hasMoreFrames=true for the whole batch — the
+	// precondition for the deferred-cleanup bug.
+	hdr := encodeH2Headers(t, [][2]string{
+		{":method", "GET"}, {":scheme", "http"}, {":path", "/"}, {":authority", "x"},
+	})
+	var in bytes.Buffer
+	in.WriteString(frame.ClientPreface)
+	fr := http2.NewFramer(&in, nil)
+	if err := fr.WriteSettings(); err != nil {
+		t.Fatalf("WriteSettings: %v", err)
+	}
+	for i := 0; i < nStreams; i++ {
+		sid := uint32(2*i + 1)
+		if err := fr.WriteRawFrame(http2.FrameHeaders,
+			http2.FlagHeadersEndStream|http2.FlagHeadersEndHeaders, sid, hdr); err != nil {
+			t.Fatalf("WriteHeaders sid=%d: %v", sid, err)
+		}
+	}
+	if err := ProcessH2(context.Background(), in.Bytes(), state, h, write, cfg); err != nil {
+		t.Fatalf("ProcessH2: %v", err)
+	}
+
+	// Parse the server output: no stream may be REFUSED, and every request
+	// must be answered.
+	mu.Lock()
+	out := append([]byte(nil), writes...)
+	mu.Unlock()
+	refused, served := 0, 0
+	rf := http2.NewFramer(nil, bytes.NewReader(out))
+	rf.SetMaxReadFrameSize(1 << 20)
+	for {
+		f, err := rf.ReadFrame()
+		if err != nil {
+			break
+		}
+		switch v := f.(type) {
+		case *http2.RSTStreamFrame:
+			if v.ErrCode == http2.ErrCodeRefusedStream {
+				refused++
+			}
+		case *http2.HeadersFrame:
+			served++
+		}
+	}
+	if refused != 0 {
+		t.Fatalf("got %d RST_STREAM(REFUSED_STREAM), want 0 — completed inline streams must free their MAX_CONCURRENT_STREAMS slot", refused)
+	}
+	if served != nStreams {
+		t.Fatalf("server answered %d/%d pipelined requests", served, nStreams)
 	}
 }

--- a/internal/conn/response.go
+++ b/internal/conn/response.go
@@ -365,6 +365,45 @@ func (a *h1ResponseAdapter) WriteResponse(_ *stream.Stream, status int, headers 
 	return nil
 }
 
+// h2SendableLen returns how many of the first n body bytes may be sent right
+// now, clamped by BOTH the per-stream and the connection-level send windows
+// (RFC 7540 §6.9). A return ≤ 0 means the stream must stall (buffer the whole
+// body) because at least one window is exhausted. When mgr is nil (unit-test
+// adapters constructed without a manager) only the per-stream window applies.
+func h2SendableLen(mgr *stream.Manager, s *stream.Stream, n int) int {
+	streamWin := s.GetWindowSize()
+	connWin := int32(0x7fffffff)
+	if mgr != nil {
+		connWin = mgr.GetConnectionWindow()
+	}
+	win := streamWin
+	if connWin < win {
+		win = connWin
+	}
+	if win <= 0 {
+		return 0
+	}
+	if int32(n) > win {
+		return int(win)
+	}
+	return n
+}
+
+// h2DeductWindows debits both the per-stream and the connection-level send
+// windows after n DATA bytes were written. ConsumeSendWindowFast debits both
+// in one call; with a nil manager (unit tests) only the per-stream window is
+// debited so the existing single-window behaviour is preserved.
+func h2DeductWindows(mgr *stream.Manager, s *stream.Stream, n int) {
+	if n <= 0 {
+		return
+	}
+	if mgr != nil {
+		mgr.ConsumeSendWindowFast(s, int32(n))
+		return
+	}
+	s.DeductWindow(int32(n))
+}
+
 // h2InlineResponseAdapter writes H2 response frames directly to outBuf.
 // Used by inline handlers that execute on the event loop thread. Bypasses
 // the sharded write queue entirely (no mutex, no eventfd, no goroutine).
@@ -449,21 +488,18 @@ func (a *h2InlineResponseAdapter) WriteResponse(s *stream.Stream, status int, he
 		a.outBuf.Write(appendH2Headers(nil, s.ID, endStream, headerBlock, maxFrame))
 	}
 
-	// Flow control: respect stream window for DATA frames (matches async
-	// adapter pattern). HEADERS don't consume window, always sent inline.
+	// Flow control: respect BOTH the per-stream and the connection-level
+	// send windows for DATA frames (RFC 7540 §6.9). HEADERS don't consume
+	// either window, so they are always sent inline above.
 	if len(body) > 0 {
-		window := s.GetWindowSize()
-		if window <= 0 {
+		sendLen := h2SendableLen(a.manager, s, len(body))
+		if sendLen <= 0 {
 			s.BufferOutbound(body, true)
 		} else {
-			sendLen := len(body)
-			if int32(sendLen) > window {
-				sendLen = int(window)
-			}
 			isEnd := sendLen == len(body)
 			// RFC 7540 §4.2: fragment by peer's MAX_FRAME_SIZE (not our own).
 			writeH2DataFragmented(a.outBuf, s.ID, isEnd, body[:sendLen], maxFrame)
-			s.DeductWindow(int32(sendLen))
+			h2DeductWindows(a.manager, s, sendLen)
 			if !isEnd {
 				s.BufferOutbound(body[sendLen:], true)
 			}
@@ -550,18 +586,14 @@ func (a *h2ResponseAdapter) WriteResponse(s *stream.Stream, status int, headers 
 			}
 			frameBuf = appendH2Headers(frameBuf, s.ID, endStream, headerBlock, maxFrame)
 			if len(body) > 0 {
-				window := s.GetWindowSize()
-				if window <= 0 {
+				sendLen := h2SendableLen(a.manager, s, len(body))
+				if sendLen <= 0 {
 					s.BufferOutbound(body, true)
 				} else {
-					sendLen := len(body)
-					if int32(sendLen) > window {
-						sendLen = int(window)
-					}
 					isEnd := sendLen == len(body)
 					// RFC 7540 §4.2: fragment by peer's MAX_FRAME_SIZE.
 					frameBuf = appendH2DataFragmented(frameBuf, s.ID, isEnd, body[:sendLen], maxFrame)
-					s.DeductWindow(int32(sendLen))
+					h2DeductWindows(a.manager, s, sendLen)
 					if !isEnd {
 						s.BufferOutbound(body[sendLen:], true)
 					}
@@ -608,19 +640,14 @@ func (a *h2ResponseAdapter) WriteResponse(s *stream.Stream, status int, headers 
 	frameBuf = appendH2Headers(frameBuf, s.ID, endStream, headerBlock, maxFrame)
 
 	if len(body) > 0 {
-		window := s.GetWindowSize()
-
-		if window <= 0 {
+		sendLen := h2SendableLen(a.manager, s, len(body))
+		if sendLen <= 0 {
 			s.BufferOutbound(body, true)
 		} else {
-			sendLen := len(body)
-			if int32(sendLen) > window {
-				sendLen = int(window)
-			}
 			isEnd := sendLen == len(body)
 			// RFC 7540 §4.2: fragment by peer's MAX_FRAME_SIZE.
 			frameBuf = appendH2DataFragmented(frameBuf, s.ID, isEnd, body[:sendLen], maxFrame)
-			s.DeductWindow(int32(sendLen))
+			h2DeductWindows(a.manager, s, sendLen)
 
 			if !isEnd {
 				s.BufferOutbound(body[sendLen:], true)

--- a/internal/conn/response.go
+++ b/internal/conn/response.go
@@ -365,43 +365,31 @@ func (a *h1ResponseAdapter) WriteResponse(_ *stream.Stream, status int, headers 
 	return nil
 }
 
-// h2SendableLen returns how many of the first n body bytes may be sent right
-// now, clamped by BOTH the per-stream and the connection-level send windows
-// (RFC 7540 §6.9). A return ≤ 0 means the stream must stall (buffer the whole
-// body) because at least one window is exhausted. When mgr is nil (unit-test
-// adapters constructed without a manager) only the per-stream window applies.
-func h2SendableLen(mgr *stream.Manager, s *stream.Stream, n int) int {
-	streamWin := s.GetWindowSize()
-	connWin := int32(0x7fffffff)
+// h2ReserveSend atomically reserves AND debits up to n bytes of send credit for
+// stream s across BOTH the per-stream and the connection-level send windows
+// (RFC 7540 §6.9), returning how many bytes may be sent now (the caller MUST
+// send exactly that many and buffer the rest). A return ≤ 0 means the stream
+// must stall because at least one window is exhausted. Reserving+debiting in
+// one atomic step (vs clamp-then-debit against a stale window) is what prevents
+// the event loop and a worker goroutine from over-subscribing a shared window.
+// When mgr is nil (unit-test adapters constructed without a manager) only the
+// per-stream window applies, preserving the single-window behaviour.
+func h2ReserveSend(mgr *stream.Manager, s *stream.Stream, n int) int {
+	if n <= 0 {
+		return 0
+	}
 	if mgr != nil {
-		connWin = mgr.GetConnectionWindow()
+		return int(mgr.ReserveSendWindow(s, int32(n)))
 	}
-	win := streamWin
-	if connWin < win {
-		win = connWin
-	}
+	win := s.GetWindowSize()
 	if win <= 0 {
 		return 0
 	}
 	if int32(n) > win {
-		return int(win)
-	}
-	return n
-}
-
-// h2DeductWindows debits both the per-stream and the connection-level send
-// windows after n DATA bytes were written. ConsumeSendWindowFast debits both
-// in one call; with a nil manager (unit tests) only the per-stream window is
-// debited so the existing single-window behaviour is preserved.
-func h2DeductWindows(mgr *stream.Manager, s *stream.Stream, n int) {
-	if n <= 0 {
-		return
-	}
-	if mgr != nil {
-		mgr.ConsumeSendWindowFast(s, int32(n))
-		return
+		n = int(win)
 	}
 	s.DeductWindow(int32(n))
+	return n
 }
 
 // h2InlineResponseAdapter writes H2 response frames directly to outBuf.
@@ -492,14 +480,14 @@ func (a *h2InlineResponseAdapter) WriteResponse(s *stream.Stream, status int, he
 	// send windows for DATA frames (RFC 7540 §6.9). HEADERS don't consume
 	// either window, so they are always sent inline above.
 	if len(body) > 0 {
-		sendLen := h2SendableLen(a.manager, s, len(body))
+		// Reserve+debit both windows atomically for exactly what we send.
+		sendLen := h2ReserveSend(a.manager, s, len(body))
 		if sendLen <= 0 {
 			s.BufferOutbound(body, true)
 		} else {
 			isEnd := sendLen == len(body)
 			// RFC 7540 §4.2: fragment by peer's MAX_FRAME_SIZE (not our own).
 			writeH2DataFragmented(a.outBuf, s.ID, isEnd, body[:sendLen], maxFrame)
-			h2DeductWindows(a.manager, s, sendLen)
 			if !isEnd {
 				s.BufferOutbound(body[sendLen:], true)
 			}
@@ -586,14 +574,14 @@ func (a *h2ResponseAdapter) WriteResponse(s *stream.Stream, status int, headers 
 			}
 			frameBuf = appendH2Headers(frameBuf, s.ID, endStream, headerBlock, maxFrame)
 			if len(body) > 0 {
-				sendLen := h2SendableLen(a.manager, s, len(body))
+				// Reserve+debit both windows atomically for exactly what we send.
+				sendLen := h2ReserveSend(a.manager, s, len(body))
 				if sendLen <= 0 {
 					s.BufferOutbound(body, true)
 				} else {
 					isEnd := sendLen == len(body)
 					// RFC 7540 §4.2: fragment by peer's MAX_FRAME_SIZE.
 					frameBuf = appendH2DataFragmented(frameBuf, s.ID, isEnd, body[:sendLen], maxFrame)
-					h2DeductWindows(a.manager, s, sendLen)
 					if !isEnd {
 						s.BufferOutbound(body[sendLen:], true)
 					}
@@ -640,14 +628,14 @@ func (a *h2ResponseAdapter) WriteResponse(s *stream.Stream, status int, headers 
 	frameBuf = appendH2Headers(frameBuf, s.ID, endStream, headerBlock, maxFrame)
 
 	if len(body) > 0 {
-		sendLen := h2SendableLen(a.manager, s, len(body))
+		// Reserve+debit both windows atomically for exactly what we send.
+		sendLen := h2ReserveSend(a.manager, s, len(body))
 		if sendLen <= 0 {
 			s.BufferOutbound(body, true)
 		} else {
 			isEnd := sendLen == len(body)
 			// RFC 7540 §4.2: fragment by peer's MAX_FRAME_SIZE.
 			frameBuf = appendH2DataFragmented(frameBuf, s.ID, isEnd, body[:sendLen], maxFrame)
-			h2DeductWindows(a.manager, s, sendLen)
 
 			if !isEnd {
 				s.BufferOutbound(body[sendLen:], true)

--- a/middleware/compress/go.mod
+++ b/middleware/compress/go.mod
@@ -1,6 +1,6 @@
 module github.com/goceleris/celeris/middleware/compress
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/andybalholm/brotli v1.2.1

--- a/middleware/jwt/jwt.go
+++ b/middleware/jwt/jwt.go
@@ -226,7 +226,7 @@ func cloneClaims(template jwtparse.Claims) jwtparse.Claims {
 		return &jwtparse.RegisteredClaims{}
 	default:
 		t := reflect.TypeOf(template)
-		if t.Kind() == reflect.Ptr {
+		if t.Kind() == reflect.Pointer {
 			if t.Elem().Kind() != reflect.Struct {
 				panic(fmt.Sprintf("jwt: unsupported custom claims type %T; use ClaimsFactory for non-struct pointer types", template))
 			}

--- a/middleware/metrics/go.mod
+++ b/middleware/metrics/go.mod
@@ -1,6 +1,6 @@
 module github.com/goceleris/celeris/middleware/metrics
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/goceleris/celeris v1.4.4

--- a/middleware/otel/go.mod
+++ b/middleware/otel/go.mod
@@ -1,6 +1,6 @@
 module github.com/goceleris/celeris/middleware/otel
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/goceleris/celeris v1.4.4

--- a/middleware/protobuf/go.mod
+++ b/middleware/protobuf/go.mod
@@ -1,6 +1,6 @@
 module github.com/goceleris/celeris/middleware/protobuf
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/goceleris/celeris v1.4.4

--- a/protocol/h2/frame/parser_test.go
+++ b/protocol/h2/frame/parser_test.go
@@ -9,11 +9,8 @@ import (
 
 func TestNewParser(t *testing.T) {
 	p := NewParser()
-	if p == nil {
-		t.Fatal("NewParser returned nil")
-	}
-	if p.buf == nil {
-		t.Fatal("Parser buffer is nil")
+	if p == nil || p.buf == nil {
+		t.Fatalf("NewParser returned nil or nil-buffer parser: %+v", p)
 	}
 }
 

--- a/protocol/h2/stream/flowcontrol.go
+++ b/protocol/h2/stream/flowcontrol.go
@@ -27,6 +27,61 @@ func (m *Manager) ConsumeSendWindowFast(s *Stream, n int32) {
 	s.windowSize.Add(-n)
 }
 
+// ReserveSendWindow atomically reserves up to `want` bytes of send credit for
+// stream s, debiting BOTH the per-stream and the connection-level send windows
+// by the granted amount in one operation, and returns how many bytes were
+// granted — min(want, stream window, connection window), or 0 when either
+// window is exhausted. The caller MUST send exactly the returned number of
+// bytes and buffer the rest.
+//
+// Unlike a load-then-debit (which clamps against a stale window value and can
+// be raced past the peer-authorized credit), the reservation is a pair of
+// compare-and-swap loops, so the event loop (flushStreamOutbound) and a worker
+// goroutine (async WriteResponse) can never over-subscribe a shared window:
+// each reserves exactly what it will send BEFORE writing, so the connection
+// window is never driven past the credit the peer granted (RFC 7540 §6.9).
+func (m *Manager) ReserveSendWindow(s *Stream, want int32) int32 {
+	if want <= 0 {
+		return 0
+	}
+	// Reserve from the per-stream window first.
+	var streamGrant int32
+	for {
+		sw := s.windowSize.Load()
+		if sw <= 0 {
+			return 0
+		}
+		streamGrant = want
+		if streamGrant > sw {
+			streamGrant = sw
+		}
+		if s.windowSize.CompareAndSwap(sw, sw-streamGrant) {
+			break
+		}
+	}
+	// Reserve the same amount from the connection window; if it grants less,
+	// refund the per-stream overage so the two windows stay consistent.
+	var connGrant int32
+	for {
+		cw := atomic.LoadInt32(&m.connectionWindow)
+		if cw <= 0 {
+			connGrant = 0
+			break
+		}
+		connGrant = streamGrant
+		if connGrant > cw {
+			connGrant = cw
+		}
+		if atomic.CompareAndSwapInt32(&m.connectionWindow, cw, cw-connGrant) {
+			break
+		}
+	}
+	if connGrant < streamGrant {
+		s.windowSize.Add(streamGrant - connGrant)
+	}
+	return connGrant
+}
+
 // AccumulateWindowUpdate accumulates window credits without sending immediately.
 func (m *Manager) AccumulateWindowUpdate(streamID uint32, increment uint32) {
 	m.windowUpdateMu.Lock()

--- a/protocol/h2/stream/flowcontrol_test.go
+++ b/protocol/h2/stream/flowcontrol_test.go
@@ -1,6 +1,8 @@
 package stream
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"golang.org/x/net/http2"
@@ -152,5 +154,88 @@ func TestBatchThreshold(t *testing.T) {
 	}
 	if fw.windowUpdates[1] != windowUpdateThreshold {
 		t.Errorf("Stream update: got %d, want %d", fw.windowUpdates[1], windowUpdateThreshold)
+	}
+}
+
+// TestReserveSendWindowConcurrent proves the connection-level send window
+// cannot be over-subscribed under concurrent reservations — the race the H2
+// 64 KB fix closes. The pre-fix path (load window, clamp, then a separate
+// atomic add) let two goroutines clamp against the same stale window and both
+// debit, driving the shared connection window negative and sending past the
+// peer-authorized credit (RFC 7540 §6.9). ReserveSendWindow does the clamp and
+// debit in one CAS, so N goroutines reserving from one window partition it
+// EXACTLY: the grants sum to the initial credit and the window lands on 0,
+// never below. Runs clean under -race.
+func TestReserveSendWindowConcurrent(t *testing.T) {
+	const (
+		initialConn = 100_000
+		goroutines  = 16
+		chunk       = 137 // odd so grants never divide the window evenly
+	)
+	m := NewManager()
+	atomic.StoreInt32(&m.connectionWindow, initialConn)
+
+	streams := make([]*Stream, goroutines)
+	for g := range streams {
+		s := m.CreateStream(uint32(2*g + 1))
+		s.SetWindowSize(1 << 30) // huge per-stream window → conn window is the only bottleneck
+		streams[g] = s
+	}
+
+	granted := make([]int64, goroutines)
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(idx int, st *Stream) {
+			defer wg.Done()
+			for {
+				n := m.ReserveSendWindow(st, chunk)
+				if n <= 0 {
+					return
+				}
+				granted[idx] += int64(n)
+			}
+		}(g, streams[g])
+	}
+	wg.Wait()
+
+	var total int64
+	for _, gtd := range granted {
+		total += gtd
+	}
+	if total != initialConn {
+		t.Fatalf("total granted = %d, want exactly %d (window over/under-subscribed)", total, initialConn)
+	}
+	if cw := m.GetConnectionWindow(); cw != 0 {
+		t.Fatalf("connectionWindow = %d after exhaustion, want 0 (must never go negative)", cw)
+	}
+}
+
+// TestReserveSendWindowClampsBothWindows checks the per-stream window binds when
+// smaller than the connection window, and that the connection window is debited
+// by exactly the granted (clamped) amount — never over-debited when the stream
+// window is the bottleneck.
+func TestReserveSendWindowClampsBothWindows(t *testing.T) {
+	m := NewManager()
+	atomic.StoreInt32(&m.connectionWindow, 10_000)
+	s := m.CreateStream(1)
+	s.SetWindowSize(300) // stream window is the bottleneck
+
+	if got := m.ReserveSendWindow(s, 1000); got != 300 {
+		t.Fatalf("grant = %d, want 300 (clamped by the per-stream window)", got)
+	}
+	if sw := s.GetWindowSize(); sw != 0 {
+		t.Fatalf("stream window = %d, want 0 (debited by grant)", sw)
+	}
+	if cw := m.GetConnectionWindow(); cw != 10_000-300 {
+		t.Fatalf("connection window = %d, want %d (debited by grant, not the request)", cw, 10_000-300)
+	}
+	// Stream window exhausted → further reservations grant 0 and must not touch
+	// the connection window.
+	if got := m.ReserveSendWindow(s, 1000); got != 0 {
+		t.Fatalf("grant after stream exhaustion = %d, want 0", got)
+	}
+	if cw := m.GetConnectionWindow(); cw != 10_000-300 {
+		t.Fatalf("connection window leaked: %d, want %d", cw, 10_000-300)
 	}
 }

--- a/protocol/h2/stream/manager.go
+++ b/protocol/h2/stream/manager.go
@@ -134,6 +134,15 @@ func (m *Manager) TryOpenStream(id uint32) (*Stream, bool) {
 // If the stream has an async handler goroutine running (asyncRunning=true),
 // the stream is removed from the map but NOT released — the goroutine
 // will release it upon completion via ReleaseAsyncStream.
+//
+// A stream that is still in an active state when it is deleted (e.g. a
+// server-initiated RST_STREAM on a stalled stream, or a half-closed-local
+// stream whose outbound was fully flushed) must free its
+// MAX_CONCURRENT_STREAMS slot here. updateActiveCount is idempotent — if the
+// caller already transitioned the stream to Closed (the normal completion
+// path) the state is no longer active and no second decrement occurs — so
+// this is the single choke point that guarantees every removed stream frees
+// its slot exactly once, regardless of which close path reached it.
 func (m *Manager) DeleteStream(id uint32) {
 	m.mu.Lock()
 	s, ok := m.streams[id]
@@ -146,6 +155,9 @@ func (m *Manager) DeleteStream(id uint32) {
 	if !ok {
 		return
 	}
+
+	prev := State(s.state.Swap(int32(StateClosed)))
+	m.updateActiveCount(prev, StateClosed)
 
 	m.windowUpdateMu.Lock()
 	delete(m.pendingStreamUpdates, id)

--- a/protocol/h2/stream/processor.go
+++ b/protocol/h2/stream/processor.go
@@ -107,6 +107,12 @@ type Processor struct {
 	// simple, cheap, and enough to shut down a flood loop.
 	rstCount     uint32 // RST_STREAM count within the current second
 	rstWindowSec int64  // unix-second marker for the current window
+
+	// connFlushScratch is reused by flushConnWindowStalledStreams to snapshot
+	// candidate streams without allocating on every WINDOW_UPDATE(0). Frame
+	// processing is single-threaded per connection (event loop under
+	// H2State.mu), so a per-processor scratch slice is safe.
+	connFlushScratch []*Stream
 }
 
 // rstRateLimit and rstBurstLimit bound RST_STREAM arrivals. An honest
@@ -1121,94 +1127,176 @@ func (p *Processor) handleWindowUpdate(f *http2.WindowUpdateFrame) error {
 				break
 			}
 		}
-	} else {
-		stream, ok := p.manager.GetStream(f.StreamID)
-		if !ok {
-			if f.StreamID <= p.manager.GetLastClientStreamID() {
-				return nil
-			}
-			return p.GoAwayErr(p.manager.GetLastStreamID(), http2.ErrCodeProtocol,
-				[]byte("WINDOW_UPDATE on idle stream"),
-				fmt.Errorf("WINDOW_UPDATE on idle stream %d", f.StreamID))
-		}
+		// Connection-level credit may unblock streams that stalled on the
+		// CONNECTION window (their per-stream window had room but the shared
+		// connection window was exhausted). Re-flush every such stream — the
+		// mirror of the per-stream branch below. Without this a stream that
+		// ran the connection window to 0 would never resume and the response
+		// would hang.
+		p.flushConnWindowStalledStreams()
+		return nil
+	}
 
-		streamState := stream.GetState()
-		if streamState == StateClosed {
+	stream, ok := p.manager.GetStream(f.StreamID)
+	if !ok {
+		if f.StreamID <= p.manager.GetLastClientStreamID() {
 			return nil
 		}
+		return p.GoAwayErr(p.manager.GetLastStreamID(), http2.ErrCodeProtocol,
+			[]byte("WINDOW_UPDATE on idle stream"),
+			fmt.Errorf("WINDOW_UPDATE on idle stream %d", f.StreamID))
+	}
 
-		// CAS loop for atomic window update with overflow check.
-		var newWin int32
-		for {
-			old := stream.LoadWindowSize()
-			newWindow := int64(old) + int64(f.Increment)
-			if newWindow > 0x7fffffff {
-				// RST and reclaim the slot via the shared close path so the
-				// active stream's MAX_CONCURRENT_STREAMS slot is freed.
-				_ = p.sendRSTStreamAndMarkClosed(f.StreamID, http2.ErrCodeFlowControl)
-				return fmt.Errorf("stream %d window overflow: %d + %d > 2^31-1", f.StreamID, old, f.Increment)
-			}
-			//nolint:gosec // G115: safe conversion, newWindow validated <= 2^31-1 above
-			newWin = int32(newWindow)
-			if stream.CompareAndSwapWindowSize(old, newWin) {
-				break
-			}
+	streamState := stream.GetState()
+	if streamState == StateClosed {
+		return nil
+	}
+
+	// CAS loop for atomic window update with overflow check.
+	for {
+		old := stream.LoadWindowSize()
+		newWindow := int64(old) + int64(f.Increment)
+		if newWindow > 0x7fffffff {
+			// RST and reclaim the slot via the shared close path so the
+			// active stream's MAX_CONCURRENT_STREAMS slot is freed.
+			_ = p.sendRSTStreamAndMarkClosed(f.StreamID, http2.ErrCodeFlowControl)
+			return fmt.Errorf("stream %d window overflow: %d + %d > 2^31-1", f.StreamID, old, f.Increment)
 		}
-
-		// Flush buffered outbound data now that window space is available.
-		var flushedAll bool
-		stream.mu.Lock()
-		if stream.OutboundBuffer != nil && stream.OutboundBuffer.Len() > 0 {
-			if newWin > 0 {
-				buffered := stream.OutboundBuffer.Bytes()
-				sendLen := len(buffered)
-				if int32(sendLen) > newWin {
-					sendLen = int(newWin)
-				}
-				isEnd := sendLen == len(buffered) && stream.OutboundEndStream
-				stream.windowSize.Add(-int32(sendLen))
-				stream.mu.Unlock()
-
-				_ = p.writer.WriteData(f.StreamID, isEnd, buffered[:sendLen])
-				p.flush()
-
-				stream.mu.Lock()
-				if sendLen == len(buffered) {
-					stream.OutboundBuffer.Reset()
-					if isEnd {
-						flushedAll = true
-					}
-				} else {
-					remaining := make([]byte, len(buffered)-sendLen)
-					copy(remaining, buffered[sendLen:])
-					stream.OutboundBuffer.Reset()
-					stream.OutboundBuffer.Write(remaining)
-				}
-			}
+		//nolint:gosec // G115: safe conversion, newWindow validated <= 2^31-1 above
+		if stream.CompareAndSwapWindowSize(old, int32(newWindow)) {
+			break
 		}
-		stream.mu.Unlock()
+	}
 
-		// If all buffered data has been flushed with END_STREAM, the handler
-		// goroutine already completed. Transition to closed and clean up.
-		if flushedAll {
-			switch streamState {
-			case StateHalfClosedRemote:
-				stream.SetState(StateClosed)
-			case StateOpen:
-				stream.SetState(StateHalfClosedLocal)
-			}
-			p.manager.DeleteStream(f.StreamID)
+	// Flush buffered outbound data now that per-stream window space is
+	// available (clamped + debited against the connection window too).
+	if p.flushStreamOutbound(stream) {
+		switch streamState {
+		case StateHalfClosedRemote:
+			stream.SetState(StateClosed)
+		case StateOpen:
+			stream.SetState(StateHalfClosedLocal)
 		}
+		p.manager.DeleteStream(f.StreamID)
+	}
 
-		if stream.ReceivedWindowUpd != nil {
-			select {
-			//nolint:gosec // G115: safe conversion
-			case stream.ReceivedWindowUpd <- int32(f.Increment):
-			default:
-			}
+	if stream.ReceivedWindowUpd != nil {
+		select {
+		//nolint:gosec // G115: safe conversion
+		case stream.ReceivedWindowUpd <- int32(f.Increment):
+		default:
 		}
 	}
 	return nil
+}
+
+// flushStreamOutbound sends as much of a stream's buffered outbound DATA as
+// the current per-stream AND connection send windows allow, debiting both
+// windows (RFC 7540 §6.9). It returns true only when the entire buffer was
+// flushed AND it carried END_STREAM — i.e. the stream is now fully sent and
+// the caller should transition it to closed and reclaim its slot. A stream
+// that still has bytes buffered (because either window was exhausted mid-flush)
+// returns false and stays alive for the next WINDOW_UPDATE.
+func (p *Processor) flushStreamOutbound(s *Stream) bool {
+	flushedAll := false
+	s.mu.Lock()
+	if s.OutboundBuffer == nil || s.OutboundBuffer.Len() == 0 {
+		s.mu.Unlock()
+		return false
+	}
+
+	buffered := s.OutboundBuffer.Bytes()
+	streamWin := s.windowSize.Load()
+	connWin := atomic.LoadInt32(&p.manager.connectionWindow)
+	sendLen := len(buffered)
+	if int32(sendLen) > streamWin {
+		sendLen = int(streamWin)
+	}
+	if int32(sendLen) > connWin {
+		sendLen = int(connWin)
+	}
+	if sendLen <= 0 {
+		// No room on at least one window — leave everything buffered.
+		s.mu.Unlock()
+		return false
+	}
+
+	isEnd := sendLen == len(buffered) && s.OutboundEndStream
+	s.windowSize.Add(-int32(sendLen))
+	atomic.AddInt32(&p.manager.connectionWindow, -int32(sendLen))
+	s.mu.Unlock()
+
+	_ = p.writer.WriteData(s.ID, isEnd, buffered[:sendLen])
+	p.flush()
+
+	s.mu.Lock()
+	if sendLen == len(buffered) {
+		s.OutboundBuffer.Reset()
+		if isEnd {
+			flushedAll = true
+		}
+	} else {
+		remaining := make([]byte, len(buffered)-sendLen)
+		copy(remaining, buffered[sendLen:])
+		s.OutboundBuffer.Reset()
+		s.OutboundBuffer.Write(remaining)
+	}
+	s.mu.Unlock()
+	return flushedAll
+}
+
+// flushConnWindowStalledStreams re-flushes every stream that still has
+// buffered outbound DATA after a connection-level WINDOW_UPDATE(0) credited
+// the shared window. A stream whose per-stream window had room but which
+// stalled because the connection window hit zero is invisible to the
+// per-stream WINDOW_UPDATE path (the peer only sends connection credit), so
+// this is the sole place such a stream resumes. Fully-sent streams are
+// transitioned to closed and have their MAX_CONCURRENT_STREAMS slot reclaimed,
+// mirroring the per-stream branch.
+func (p *Processor) flushConnWindowStalledStreams() {
+	// Nothing can be unblocked if the connection window is still empty.
+	if atomic.LoadInt32(&p.manager.connectionWindow) <= 0 {
+		return
+	}
+	// Snapshot the candidate streams under the manager lock; flushing itself
+	// takes per-stream locks and may call DeleteStream, so it must run outside
+	// the manager read lock. The scratch slice is reused across calls to avoid
+	// allocating on this path.
+	candidates := p.connFlushScratch[:0]
+	p.manager.mu.RLock()
+	for _, s := range p.manager.streams {
+		if s.GetState() == StateClosed {
+			continue
+		}
+		candidates = append(candidates, s)
+	}
+	p.manager.mu.RUnlock()
+
+	for _, s := range candidates {
+		// Bail out early once the connection window is exhausted again —
+		// no further stream can make progress until the next credit.
+		if atomic.LoadInt32(&p.manager.connectionWindow) <= 0 {
+			break
+		}
+		streamState := s.GetState()
+		if streamState == StateClosed {
+			continue
+		}
+		if p.flushStreamOutbound(s) {
+			switch streamState {
+			case StateHalfClosedRemote:
+				s.SetState(StateClosed)
+			case StateOpen:
+				s.SetState(StateHalfClosedLocal)
+			}
+			p.manager.DeleteStream(s.ID)
+		}
+	}
+
+	// Retain the grown backing array for the next call but drop the *Stream
+	// references so released (pooled) streams aren't pinned between calls.
+	clear(candidates)
+	p.connFlushScratch = candidates[:0]
 }
 
 // handleRSTStream processes RST_STREAM frames. Enforces a rate limit
@@ -1519,6 +1607,7 @@ func (p *Processor) HandleRawWindowUpdate(streamID uint32, payload []byte) error
 				break
 			}
 		}
+		p.flushConnWindowStalledStreams()
 		return nil
 	}
 
@@ -1532,11 +1621,11 @@ func (p *Processor) HandleRawWindowUpdate(streamID uint32, payload []byte) error
 			fmt.Errorf("WINDOW_UPDATE on idle stream %d", streamID))
 	}
 
-	if stream.GetState() == StateClosed {
+	streamState := stream.GetState()
+	if streamState == StateClosed {
 		return nil
 	}
 
-	var newWin int32
 	for {
 		old := stream.LoadWindowSize()
 		newWindow := int64(old) + int64(increment)
@@ -1547,47 +1636,14 @@ func (p *Processor) HandleRawWindowUpdate(streamID uint32, payload []byte) error
 			return fmt.Errorf("stream %d window overflow: %d + %d > 2^31-1", streamID, old, increment)
 		}
 		//nolint:gosec // G115: safe conversion
-		newWin = int32(newWindow)
-		if stream.CompareAndSwapWindowSize(old, newWin) {
+		if stream.CompareAndSwapWindowSize(old, int32(newWindow)) {
 			break
 		}
 	}
 
-	// Flush buffered outbound data now that window space is available.
-	var flushedAll bool
-	streamState := stream.GetState()
-	stream.mu.Lock()
-	if stream.OutboundBuffer != nil && stream.OutboundBuffer.Len() > 0 {
-		if newWin > 0 {
-			buffered := stream.OutboundBuffer.Bytes()
-			sendLen := len(buffered)
-			if int32(sendLen) > newWin {
-				sendLen = int(newWin)
-			}
-			isEnd := sendLen == len(buffered) && stream.OutboundEndStream
-			stream.windowSize.Add(-int32(sendLen))
-			stream.mu.Unlock()
-
-			_ = p.writer.WriteData(streamID, isEnd, buffered[:sendLen])
-			p.flush()
-
-			stream.mu.Lock()
-			if sendLen == len(buffered) {
-				stream.OutboundBuffer.Reset()
-				if isEnd {
-					flushedAll = true
-				}
-			} else {
-				remaining := make([]byte, len(buffered)-sendLen)
-				copy(remaining, buffered[sendLen:])
-				stream.OutboundBuffer.Reset()
-				stream.OutboundBuffer.Write(remaining)
-			}
-		}
-	}
-	stream.mu.Unlock()
-
-	if flushedAll {
+	// Flush buffered outbound data now that per-stream window space is
+	// available (clamped + debited against the connection window too).
+	if p.flushStreamOutbound(stream) {
 		switch streamState {
 		case StateHalfClosedRemote:
 			stream.SetState(StateClosed)

--- a/protocol/h2/stream/processor.go
+++ b/protocol/h2/stream/processor.go
@@ -1143,8 +1143,9 @@ func (p *Processor) handleWindowUpdate(f *http2.WindowUpdateFrame) error {
 			old := stream.LoadWindowSize()
 			newWindow := int64(old) + int64(f.Increment)
 			if newWindow > 0x7fffffff {
-				_ = p.writer.WriteRSTStream(f.StreamID, http2.ErrCodeFlowControl)
-				p.flush()
+				// RST and reclaim the slot via the shared close path so the
+				// active stream's MAX_CONCURRENT_STREAMS slot is freed.
+				_ = p.sendRSTStreamAndMarkClosed(f.StreamID, http2.ErrCodeFlowControl)
 				return fmt.Errorf("stream %d window overflow: %d + %d > 2^31-1", f.StreamID, old, f.Increment)
 			}
 			//nolint:gosec // G115: safe conversion, newWindow validated <= 2^31-1 above
@@ -1540,8 +1541,9 @@ func (p *Processor) HandleRawWindowUpdate(streamID uint32, payload []byte) error
 		old := stream.LoadWindowSize()
 		newWindow := int64(old) + int64(increment)
 		if newWindow > 0x7fffffff {
-			_ = p.writer.WriteRSTStream(streamID, http2.ErrCodeFlowControl)
-			p.flush()
+			// RST and reclaim the slot via the shared close path so the
+			// active stream's MAX_CONCURRENT_STREAMS slot is freed.
+			_ = p.sendRSTStreamAndMarkClosed(streamID, http2.ErrCodeFlowControl)
 			return fmt.Errorf("stream %d window overflow: %d + %d > 2^31-1", streamID, old, increment)
 		}
 		//nolint:gosec // G115: safe conversion

--- a/protocol/h2/stream/processor.go
+++ b/protocol/h2/stream/processor.go
@@ -1220,15 +1220,10 @@ func (p *Processor) flushStreamOutbound(s *Stream) bool {
 	}
 
 	buffered := s.OutboundBuffer.Bytes()
-	streamWin := s.windowSize.Load()
-	connWin := atomic.LoadInt32(&p.manager.connectionWindow)
-	sendLen := len(buffered)
-	if int32(sendLen) > streamWin {
-		sendLen = int(streamWin)
-	}
-	if int32(sendLen) > connWin {
-		sendLen = int(connWin)
-	}
+	// Atomically reserve+debit both windows for exactly the bytes we are about
+	// to send, so a concurrent async-path reservation can never push a shared
+	// window past the peer-authorized credit (RFC 7540 §6.9).
+	sendLen := int(p.manager.ReserveSendWindow(s, int32(len(buffered))))
 	if sendLen <= 0 {
 		// No room on at least one window — leave everything buffered.
 		s.mu.Unlock()
@@ -1236,8 +1231,6 @@ func (p *Processor) flushStreamOutbound(s *Stream) bool {
 	}
 
 	isEnd := sendLen == len(buffered) && s.OutboundEndStream
-	s.windowSize.Add(-int32(sendLen))
-	atomic.AddInt32(&p.manager.connectionWindow, -int32(sendLen))
 	s.mu.Unlock()
 
 	_ = p.writer.WriteData(s.ID, isEnd, buffered[:sendLen])

--- a/protocol/h2/stream/processor.go
+++ b/protocol/h2/stream/processor.go
@@ -615,17 +615,17 @@ func (p *Processor) executeHandlerInline(stream *Stream) {
 		return
 	}
 
-	// When more frames follow in the recv buffer, defer the state
-	// transition and cleanup until FlushInlineCleanup (after the frame
-	// loop). This keeps activeStreams elevated so TryOpenStream correctly
-	// enforces MAX_CONCURRENT_STREAMS for subsequent HEADERS frames.
-	// Fixes h2spec: concurrent stream limit exceeded.
-	if p.hasMoreFrames {
-		p.pendingInlineCleanup = append(p.pendingInlineCleanup, stream)
-		keepAlive = true
-		return
-	}
-
+	// Transition the stream state NOW so a fully-completed stream (END_STREAM
+	// sent, no buffered outbound) stops counting toward MAX_CONCURRENT_STREAMS
+	// immediately. Per RFC 7540 §5.1.2 only open / half-closed streams count,
+	// so a closed stream must free its slot at once — otherwise a single recv
+	// buffer carrying more than MAX_CONCURRENT_STREAMS pipelined complete
+	// requests (e.g. 64 KB GETs whose responses backpressure TCP) would see
+	// the 101st+ HEADERS spuriously REFUSED even though streams 1..100 are
+	// already done. Inline handlers run sequentially, so at most one stream is
+	// genuinely open at a time; a still-open stream never reaches this point
+	// (it returns early above), so the concurrency limit stays enforced for
+	// real concurrent streams.
 	state := stream.GetState()
 	if state == StateOpen || state == StateHalfClosedRemote {
 		if state == StateHalfClosedRemote {
@@ -633,6 +633,17 @@ func (p *Processor) executeHandlerInline(stream *Stream) {
 		} else {
 			stream.SetState(StateHalfClosedLocal)
 		}
+	}
+
+	// When more frames follow in the recv buffer, defer only the map removal
+	// and Release to FlushInlineCleanup (after the frame loop) so later frames
+	// in the same batch that reference this stream still find it. The state
+	// transition above already ran; FlushInlineCleanup re-applies it
+	// idempotently before removing the stream.
+	if p.hasMoreFrames {
+		p.pendingInlineCleanup = append(p.pendingInlineCleanup, stream)
+		keepAlive = true
+		return
 	}
 }
 

--- a/protocol/h2/stream/processor.go
+++ b/protocol/h2/stream/processor.go
@@ -591,6 +591,14 @@ func (p *Processor) executeHandlerInline(stream *Stream) {
 			return
 		}
 
+		// Free the MAX_CONCURRENT_STREAMS slot before removal. A handler that
+		// returned without writing a response (error return, empty/204-style
+		// handler, recovered panic) or a stream left half-closed-local still
+		// counts as active, and RemoveStreamFromMap does NOT touch
+		// activeStreams — so transition to Closed here, decrementing exactly
+		// once via updateActiveCount. Idempotent: a fully-completed stream
+		// already transitioned to Closed above is a no-op (no double-decrement).
+		stream.SetState(StateClosed)
 		p.manager.RemoveStreamFromMap(stream.ID)
 		stream.Release()
 	}()
@@ -683,6 +691,12 @@ func (p *Processor) executeHandler(stream *Stream) {
 			return
 		}
 
+		// Free the MAX_CONCURRENT_STREAMS slot before removal (see
+		// executeHandlerInline): a no-write handler, an error return, or a
+		// half-closed-local stream still counts as active and RemoveStreamFromMap
+		// does not decrement, so transition to Closed here (idempotent for an
+		// already-Closed stream — no double-decrement).
+		stream.SetState(StateClosed)
 		p.manager.RemoveStreamFromMap(stream.ID)
 		stream.Release()
 	}()

--- a/server_test.go
+++ b/server_test.go
@@ -26,21 +26,15 @@ func TestServerEngineInfo(t *testing.T) {
 	var fe engine.Engine = &fakeEngine{}
 	s.engineRef.Store(&fe)
 	info := s.EngineInfo()
-	if info == nil {
-		t.Fatal("expected non-nil EngineInfo")
-	}
-	if info.Type != Std {
-		t.Fatalf("expected Std, got %v", info.Type)
+	if info == nil || info.Type != Std {
+		t.Fatalf("expected non-nil EngineInfo of type Std, got %+v", info)
 	}
 }
 
 func TestNewServer(t *testing.T) {
 	s := New(Config{Addr: ":9090"})
-	if s == nil {
-		t.Fatal("expected non-nil server")
-	}
-	if s.config.Addr != ":9090" {
-		t.Fatalf("expected :9090, got %s", s.config.Addr)
+	if s == nil || s.config.Addr != ":9090" {
+		t.Fatalf("expected non-nil server with addr :9090, got %+v", s)
 	}
 }
 

--- a/test/benchcmp_sse/go.mod
+++ b/test/benchcmp_sse/go.mod
@@ -1,6 +1,6 @@
 module github.com/goceleris/celeris/test/benchcmp_sse
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/goceleris/celeris v1.4.2

--- a/test/benchcmp_ws/go.mod
+++ b/test/benchcmp_ws/go.mod
@@ -1,6 +1,6 @@
 module github.com/goceleris/celeris/test/benchcmp_ws
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/goceleris/celeris v1.4.2

--- a/test/drivercmp/memcached/go.mod
+++ b/test/drivercmp/memcached/go.mod
@@ -1,6 +1,6 @@
 module github.com/goceleris/celeris/test/drivercmp/memcached
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/bradfitz/gomemcache v0.0.0-20250403215159-8d39553ac7cf

--- a/test/drivercmp/postgres/go.mod
+++ b/test/drivercmp/postgres/go.mod
@@ -1,6 +1,6 @@
 module github.com/goceleris/celeris/test/drivercmp/postgres
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/goceleris/celeris v0.0.0

--- a/test/drivercmp/redis/go.mod
+++ b/test/drivercmp/redis/go.mod
@@ -1,6 +1,6 @@
 module github.com/goceleris/celeris/test/drivercmp/redis
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/goceleris/celeris v0.0.0

--- a/test/perfmatrix/go.mod
+++ b/test/perfmatrix/go.mod
@@ -1,6 +1,6 @@
 module github.com/goceleris/celeris/test/perfmatrix
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/HdrHistogram/hdrhistogram-go v1.2.0


### PR DESCRIPTION
Fixes #309.

## Problem

The epoll engine **fatally crashes** (`fatal error: sync: unlock of unlocked mutex`) on the **first WebSocket upgrade (`/ws`) or SSE request (`/events`)** when the server has per-handler async enabled (any route uses `.Async()`). The process dies — uncatchable by recovery middleware (it's a `fatal error`, not a `panic`).

Engine matrix (Linux/amd64): **epoll-h1-sync crashes** on both `/ws` and `/events`; iouring-h1-async, iouring-auto+upg-async, and std-h1 are fine.

## Root cause

`Loop.async` is forced `true` whenever any route opts into `.Async()` (`server.go`: `hasAsyncRoutes()` → `AsyncHandlers=true`), so the "sync" engine label still runs the loop in async mode. With per-handler async (#300/#302), a not-yet-promoted async-mode conn runs its **first request inline on the event-loop thread** (`tryInline` at `drainRead`). A **sync route** — `/ws` and `/events` are not themselves `.Async()` (detached flows run async via their own middleware goroutine) — does not bail with `ErrAsyncDispatch`, so its handler runs inline and calls `Context.Detach()` → `OnDetach` **while `cs.detachMu` was never Locked** (the inline path only locks it at the post-handler flush).

The `OnDetach` guard (added for #273) then unconditionally `Unlock`s `detachMu` whenever `l.async` — faulting on the unlocked mutex. #273's invariant ("`l.async` ⟹ the dispatch goroutine Locked `detachMu`") was broken by the #300 inline fast path.

## Fix

One-condition change: gate the `Unlock` on `cs.asyncPromoted`.

```go
-if l.async && cs.detachMu != nil && !cs.asyncDetachUnlocked {
+if l.async && cs.asyncPromoted && cs.detachMu != nil && !cs.asyncDetachUnlocked {
```

`detachMu` is Locked around `ProcessH1` **only** by `runAsyncHandler` (the dispatch goroutine), which runs exclusively for *promoted* conns. Restricting the `Unlock` to promoted conns means:

- **dispatch-goroutine path (promoted):** lock IS held → `Unlock` balanced; `asyncDetachUnlocked` still set so `runAsyncHandler` skips its symmetric `Unlock`. **Byte-for-byte identical to today** on this path → the #273 deadlock and the #284 subsequent-upgrade hang cannot recur.
- **inline path (not promoted):** guard skipped → no spurious `Unlock`. The inline flush owns its own `Lock`/`Unlock` around `flushWrites`, so the guarded `writeFn` (which re-locks) still serialises with the event loop.
- **pure sync (`l.async == false`):** unchanged.

`asyncPromoted` is set on the event-loop thread before `runAsyncHandler` is spawned, and `OnDetach` on the dispatch path runs *inside* `runAsyncHandler`, so the flag is already `true` when that path reaches the guard — no race.

## Tests

New `engine/epoll/detach_inline_regression_linux_test.go` reproduces the exact untested shape — **async data route + sync `/ws` + sync `/events`, `AsyncHandlers` left default** — and asserts, across all engines, `/ws`→101, `/events`→200, **and that the SUT is still alive afterwards** (a crash would kill the test binary). Pre-fix this crashes the test on epoll.

The pre-existing `middleware/{websocket,sse}/*_engine_linux_test` register only the streaming route (no `.Async()` data route), so they never reached the inline-with-async-engine path — which is why the bug shipped.

## Verification

On Linux (msa2-server), the fixed adapter binary:

| engine | `/ws` | `/events` | alive after |
|---|---|---|---|
| epoll-h1-sync | **101** | **200** | ✅ (pre-fix: 000/CRASH) |
| iouring-h1-async | 101 | 200 | ✅ |
| iouring-auto+upg-async | 101 | 200 | ✅ |
| std-h1 | 101 | 200 | ✅ |

Stress on epoll-sync: **20/20 sequential WS upgrades** (covers the #284 subsequent-upgrade case), 20/20 sequential SSE, concurrent SSE 15/15, server alive, no `DATA RACE`. Portable `middleware/{websocket,sse}` unit suites pass; `go vet` + `go build` clean for linux/amd64.

> CI runs the full `engine/epoll` + race suite on Linux (cannot run epoll/io_uring on the dev macOS host); please confirm green before merge.

**Milestone:** v1.4.13.
