### PR TITLE
fix(iouring): wall-clock deferred connState release (churn-close memory leak)

### DIFF
--- a/engine/iouring/pending_release_test.go
+++ b/engine/iouring/pending_release_test.go
@@ -1,0 +1,101 @@
+//go:build linux
+
+package iouring
+
+import (
+	"testing"
+	"time"
+)
+
+// TestPendingReleaseIsTimeBased is the regression guard for the churn-close
+// memory blowup. The deferred connState-release window (which holds a closed
+// connState alive past io_uring's recv-cancellation latency to avoid the #256
+// kernel-write use-after-free) MUST be wall-clock based, not event-loop
+// iteration based.
+//
+// An iteration count is meaningless across load regimes:
+//   - under churn-close the loop spins so fast that N iterations elapse in
+//     microseconds (potentially SHORTER than the cancel latency → reopening the
+//     #256 UAF) while the high close rate piles tens of thousands of connStates
+//     into the queue at ~16 KB each;
+//   - when the loop is idle (SubmitAndWaitTimeout up to ~100 ms/iter) N
+//     iterations stretch to minutes, pinning that memory long after the load
+//     drops. Observed: RSS ~35 MB → ~1.9 GB under churn, retained for ~8 min.
+//
+// The fix records a wall-clock deadline (now + pendingReleaseHoldNanos) at
+// enqueue and drains against w.cachedNow, so the queue depth is bounded by
+// close_rate × hold and drains promptly once churn stops.
+func TestPendingReleaseIsTimeBased(t *testing.T) {
+	w := &Worker{}
+	start := time.Now().UnixNano()
+
+	w.queuePendingRelease(&connState{})         // pooled-recycle path
+	w.queuePendingReleaseDetached(&connState{}) // detached path (drops the ref)
+	if got := len(w.pendingRelease); got != 2 {
+		t.Fatalf("queued = %d, want 2", got)
+	}
+
+	// Each entry's release deadline is a future wall-clock timestamp, not an
+	// iteration counter.
+	for i, e := range w.pendingRelease {
+		if e.releaseAtNanos < start+pendingReleaseHoldNanos {
+			t.Fatalf("entry %d releaseAtNanos=%d < start+hold=%d: window is not wall-clock based",
+				i, e.releaseAtNanos, start+pendingReleaseHoldNanos)
+		}
+	}
+
+	// While cachedNow is still before the deadline, NO number of event-loop
+	// iterations may drain an entry. The old iteration-based code drained once
+	// iterCount advanced past releaseAtIter — exactly the bug this guards.
+	w.cachedNow = start // well before start+hold
+	for i := 0; i < 100_000; i++ {
+		w.drainPendingRelease()
+	}
+	if got := len(w.pendingRelease); got != 2 {
+		t.Fatalf("drained before the wall-clock hold elapsed: %d left, want 2 "+
+			"(iteration-based-release regression)", got)
+	}
+
+	// Once wall-clock advances past the hold, both entries drain (the detached
+	// one drops its ref; the pooled one is recycled to the sync.Pool).
+	w.cachedNow = start + pendingReleaseHoldNanos + int64(time.Second)
+	w.drainPendingRelease()
+	if got := len(w.pendingRelease); got != 0 {
+		t.Fatalf("not drained after the hold elapsed: %d left, want 0", got)
+	}
+}
+
+// TestPendingReleaseDrainsFIFOByDeadline verifies entries drain in enqueue order
+// as the wall clock crosses each deadline, and that a partial advance drains only
+// the entries whose hold has elapsed (the queue is not all-or-nothing).
+func TestPendingReleaseDrainsFIFOByDeadline(t *testing.T) {
+	w := &Worker{}
+
+	// Enqueue three entries ~10 ms apart in wall-clock terms by pinning cachedNow
+	// is not enough (queue uses time.Now()), so capture each deadline.
+	w.queuePendingRelease(&connState{})
+	d0 := w.pendingRelease[0].releaseAtNanos
+	time.Sleep(2 * time.Millisecond)
+	w.queuePendingRelease(&connState{})
+	time.Sleep(2 * time.Millisecond)
+	w.queuePendingRelease(&connState{})
+	d2 := w.pendingRelease[2].releaseAtNanos
+
+	if !(d0 < d2) {
+		t.Fatalf("deadlines not monotonic: d0=%d d2=%d", d0, d2)
+	}
+
+	// Advance the clock to just past the first deadline only.
+	w.cachedNow = d0
+	w.drainPendingRelease()
+	if got := len(w.pendingRelease); got != 2 {
+		t.Fatalf("after crossing first deadline: %d left, want 2", got)
+	}
+
+	// Advance past the last deadline → everything drains.
+	w.cachedNow = d2 + 1
+	w.drainPendingRelease()
+	if got := len(w.pendingRelease); got != 0 {
+		t.Fatalf("after crossing last deadline: %d left, want 0", got)
+	}
+}

--- a/engine/iouring/pending_release_test.go
+++ b/engine/iouring/pending_release_test.go
@@ -81,7 +81,7 @@ func TestPendingReleaseDrainsFIFOByDeadline(t *testing.T) {
 	w.queuePendingRelease(&connState{})
 	d2 := w.pendingRelease[2].releaseAtNanos
 
-	if !(d0 < d2) {
+	if d0 >= d2 {
 		t.Fatalf("deadlines not monotonic: d0=%d d2=%d", d0, d2)
 	}
 

--- a/engine/iouring/worker.go
+++ b/engine/iouring/worker.go
@@ -70,20 +70,28 @@ const bufRingCount = 1024
 // what we need; the recycle path resetting fields would race with the
 // goroutine's defer that reads cs.fd / cs.asyncInBuf.
 type pendingReleaseEntry struct {
-	cs            *connState
-	releaseAtIter uint64
-	detached      bool
+	cs             *connState
+	releaseAtNanos int64
+	detached       bool
 }
 
-// pendingReleaseIters is the number of event-loop iterations to
-// hold a closed connState before returning to the pool. io_uring's
-// unix.Close(fd) → cancel-pending-ops → ECANCELED CQE path
-// completes within ~1 ms on Linux 6.x even under load, so ~5 000
-// iterations (≈50 ms on a worker looping at 100 k+ iter/s) is an
-// order-of-magnitude safety margin. Pushing this higher only
-// inflates the queue depth × per-cs memory footprint under
-// churn-close load without adding real safety.
-const pendingReleaseIters uint64 = 5_000
+// pendingReleaseHoldNanos is the WALL-CLOCK duration to hold a closed
+// connState before returning it to the pool. io_uring's
+// unix.Close(fd) → cancel-pending-ops → ECANCELED CQE path completes
+// within ~1 ms on Linux 6.x even under load, so 100 ms is an
+// order-of-magnitude safety margin.
+//
+// This MUST be time-based, not iteration-based. An iteration count is
+// meaningless across load regimes: under churn-close the loop spins
+// fast so a fixed N iterations elapses in well under a millisecond
+// (risking the #256 use-after-free it guards against) while the high
+// close rate piles tens of thousands of connStates into the queue
+// (~16 KB each → multi-GB RSS); and when the loop is idle the wait is
+// SubmitAndWaitTimeout(adaptiveTimeout) up to 100 ms per iteration, so
+// N iterations stretches to minutes and pins that memory long after
+// the load drops. A wall-clock window bounds the queue to
+// close_rate × hold and drains promptly once churn stops.
+const pendingReleaseHoldNanos int64 = int64(100 * time.Millisecond)
 
 // Worker is an io_uring event-loop worker pinned to a single OS thread.
 type Worker struct {
@@ -158,9 +166,9 @@ type Worker struct {
 	// for its stack pool, yielding a SIGSEGV in runtime.stackalloc
 	// dereferencing HTTP request bytes as a pointer (#256 SEGV
 	// class — not race-detectable because the writer is the kernel,
-	// not Go code). Holding cs for pendingReleaseIters iterations
-	// after close keeps cs.buf's backing array alive through the
-	// cancellation window.
+	// not Go code). Holding cs for pendingReleaseHoldNanos of
+	// wall-clock time after close keeps cs.buf's backing array alive
+	// through the cancellation window.
 	pendingRelease []pendingReleaseEntry
 
 	dirtyHead      *connState // head of intrusive doubly-linked dirty list
@@ -1976,8 +1984,8 @@ func (w *Worker) closeConn(fd int) {
 // invariant this enforces.
 func (w *Worker) queuePendingRelease(cs *connState) {
 	w.pendingRelease = append(w.pendingRelease, pendingReleaseEntry{
-		cs:            cs,
-		releaseAtIter: w.iterCount + pendingReleaseIters,
+		cs:             cs,
+		releaseAtNanos: time.Now().UnixNano() + pendingReleaseHoldNanos,
 	})
 }
 
@@ -1990,22 +1998,25 @@ func (w *Worker) queuePendingRelease(cs *connState) {
 // recover() block, reading cs.fd and re-clearing cs.asyncInBuf, when
 // finishCloseDetached returns. Recycling cs through releaseConnState
 // at this point races those reads. We just keep the strong ref alive
-// for pendingReleaseIters and let GC collect — the goroutine has long
+// for pendingReleaseHoldNanos and let GC collect — the goroutine has long
 // since finished by then, the kernel has long since drained any
 // pending recv targeting cs.buf, and Go's GC reclaims cs and cs.buf
 // without any chance of the kernel writing inbound HTTP bytes into
 // memory the runtime has repurposed (#256 SIGSEGV class).
 func (w *Worker) queuePendingReleaseDetached(cs *connState) {
 	w.pendingRelease = append(w.pendingRelease, pendingReleaseEntry{
-		cs:            cs,
-		releaseAtIter: w.iterCount + pendingReleaseIters,
-		detached:      true,
+		cs:             cs,
+		releaseAtNanos: time.Now().UnixNano() + pendingReleaseHoldNanos,
+		detached:       true,
 	})
 }
 
 // drainPendingRelease returns any connStates whose deferred-release
 // window has elapsed to the sync.Pool. FIFO because queue entries are
-// always appended with monotonically increasing releaseAtIter.
+// always appended with monotonically increasing releaseAtNanos.
+// Compared against cachedNow (refreshed each loop pass); the hold is
+// computed from a fresh time.Now() at enqueue so the window is always
+// >= pendingReleaseHoldNanos of real time even when cachedNow lags.
 //
 // Detached entries skip the pool recycle (releaseConnState would
 // reset fields that goroutine closures may still observe via the
@@ -2013,7 +2024,7 @@ func (w *Worker) queuePendingReleaseDetached(cs *connState) {
 // can reclaim the cs.
 func (w *Worker) drainPendingRelease() {
 	n := 0
-	for n < len(w.pendingRelease) && w.pendingRelease[n].releaseAtIter <= w.iterCount {
+	for n < len(w.pendingRelease) && w.pendingRelease[n].releaseAtNanos <= w.cachedNow {
 		entry := &w.pendingRelease[n]
 		if !entry.detached {
 			releaseConnState(entry.cs)
@@ -2136,7 +2147,7 @@ func (w *Worker) finishCloseDetached(fd int, cs *connState) {
 	// addr 0x48202f20544547 (#256 class, fingerprint matches the
 	// strict-matrix run2 trip on churn-close × iouring-async).
 	//
-	// pendingReleaseIters (5 000 ≈ 50 ms under load) is comfortably
+	// pendingReleaseHoldNanos (100 ms wall-clock) is comfortably
 	// longer than io_uring's close-cancels-pending-ops latency on
 	// Linux 6.x and longer than any reasonable runAsyncHandler tail.
 	w.queuePendingReleaseDetached(cs)


### PR DESCRIPTION
## Problem
The io_uring engine holds each closed `connState` in `w.pendingRelease` past io_uring's recv-cancellation window before recycling it (the #256 kernel-write use-after-free guard). That window was an **event-loop iteration count** (`pendingReleaseIters = 5000`), which doesn't map to wall-clock time across load regimes:

- **Under churn-close**: the loop spins fast → 5000 iters elapse in <1 ms while the high close rate piles ~48k connStates (~16 KB each) into the queue → **RSS 35 MB → 1.9 GB**.
- **When idle**: `SubmitAndWaitTimeout` waits up to ~100 ms/iter → 5000 iters ≈ **8 minutes**, pinning that memory long after load drops.

epoll on the identical `churn-close` load stays ~40 MB.

## Fix
Record a wall-clock deadline (`time.Now() + pendingReleaseHoldNanos`, 100 ms) at enqueue and drain against the worker's `cachedNow`. Queue depth is bounded to `close_rate × 100 ms` and drains within ~the window once churn stops. The deadline uses a fresh `time.Now()` so the hold is always ≥ 100 ms of real time even when `cachedNow` lags — safe vs #256 (100 ms is ~100× io_uring's ~1 ms cancel latency).

## Verification (real linux/io_uring)
- `TestAsyncChurnNoUseAfterFree`: **2.0M churn cycles, 0 failures**.
- New `TestPendingReleaseIsTimeBased` + `TestPendingReleaseDrainsFIFOByDeadline` guard the regression.
- Full `engine/iouring` suite green; live churn-close peak **1.9 GB → 0.8 GB** and now drains back to baseline.